### PR TITLE
fix(nanvix): add INSTALL_PREFIX for CI-friendly sysroot packaging

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build
         run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" all
+          make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" INSTALL_PREFIX="/sysroot" all
 
       - name: Test
         run: |
@@ -168,16 +168,18 @@ jobs:
         run: |
           set -euo pipefail
           ARTIFACT_NAME="sqlite-${{ matrix.platform }}-${{ matrix.process-mode }}"
-          DIST_DIR="dist/${ARTIFACT_NAME}"
-          mkdir -p "${DIST_DIR}/bin" "${DIST_DIR}/lib" "${DIST_DIR}/include"
-          # Copy executables
-          cp -f sqlite3.elf "${DIST_DIR}/bin/" 2>/dev/null || true
-          # Copy libraries
-          cp -f .libs/libsqlite3.a "${DIST_DIR}/lib/" 2>/dev/null || cp -f libsqlite3.a "${DIST_DIR}/lib/" 2>/dev/null || true
-          # Copy headers
-          cp -f sqlite3.h "${DIST_DIR}/include/" 2>/dev/null || true
-          # Create tarball
-          tar -cjf "dist/${ARTIFACT_NAME}.tar.bz2" -C dist "${ARTIFACT_NAME}"
+          STAGING="$(pwd)/staging"
+          make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" INSTALL_PREFIX="/sysroot" install DESTDIR="$STAGING"
+
+          # Preserve .elf naming convention expected by downstream consumers
+          SQLITE_BIN="$STAGING/sysroot/bin/sqlite3"
+          SQLITE_BIN_ELF="$STAGING/sysroot/bin/sqlite3.elf"
+          if [ -f "$SQLITE_BIN" ] && [ ! -e "$SQLITE_BIN_ELF" ]; then
+            cp "$SQLITE_BIN" "$SQLITE_BIN_ELF"
+          fi
+
+          mkdir -p dist
+          tar -cjf "dist/${ARTIFACT_NAME}.tar.bz2" -C "$STAGING" sysroot
           echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
 
       - name: Upload Build Artifacts

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -85,6 +85,16 @@ ifdef CONFIG_NANVIX
     LIBPOSIX := $(abspath $(NANVIX_HOME))/lib/libposix.a
     LIBZ := $(abspath $(NANVIX_HOME))/lib/libz.a
   endif
+
+  # INSTALL_PREFIX: the prefix baked into compiled artifacts.
+  # Native local builds default to SYSROOT_PATH; CI overrides to /sysroot so that
+  # release artifacts don't contain ephemeral runner paths. In Docker mode,
+  # default to a stable in-container path (/sysroot) instead of the host mount.
+  ifdef CONFIG_NANVIX_DOCKER
+  INSTALL_PREFIX ?= /sysroot
+  else
+  INSTALL_PREFIX ?= $(SYSROOT_PATH)
+  endif
 else
   # Allow clean target without CONFIG_NANVIX
   ifneq ($(MAKECMDGOALS),clean)
@@ -109,7 +119,7 @@ CONFIGURE_ENV = \
 CONFIGURE_OPTS = \
 	--disable-shared \
 	--sysroot="$(SYSROOT_PATH)" \
-	--prefix="$(SYSROOT_PATH)" \
+	--prefix="$(INSTALL_PREFIX)" \
 	--host=i686-nanvix \
 	--disable-tcl \
 	--disable-threadsafe
@@ -168,11 +178,22 @@ distclean: clean
 	git clean -fdx -e Makefile.nanvix -e NANVIX.md -e .github -e nanvix-artifacts 2>/dev/null || true
 
 # Install target (for Nanvix sysroot)
+# Use DESTDIR for staged installs: make install DESTDIR=/path/to/staging
 install: build
 ifdef CONFIG_NANVIX_DOCKER
+  ifdef DESTDIR
+	docker run --rm --user $(DOCKER_UID):$(DOCKER_GID) \
+	  -v $(CURDIR):$(DOCKER_WORKSPACE_PATH) \
+	  -v $(abspath $(NANVIX_HOME)):$(DOCKER_SYSROOT_PATH):ro \
+	  -v $(abspath $(DESTDIR)):$(abspath $(DESTDIR)) \
+	  -w $(DOCKER_WORKSPACE_PATH) \
+	  -e HOME=/tmp \
+	  $(NANVIX_DOCKER_IMAGE) make install DESTDIR="$(abspath $(DESTDIR))"
+  else
 	$(DOCKER_RUN) make install
+  endif
 else
-	make install
+	make install DESTDIR="$(DESTDIR)"
 endif
 
 .PHONY: all configure build clean distclean test install


### PR DESCRIPTION
## Summary

Adds `INSTALL_PREFIX` variable to `Makefile.nanvix` and updates CI workflow to support CI-friendly sysroot packaging.

## Changes
- **Makefile.nanvix**: Add configurable `INSTALL_PREFIX` to decouple the install destination from the build prefix, enabling CI to install into a staging sysroot
- **.github/workflows/nanvix-ci.yml**: Simplify CI workflow to use the new `INSTALL_PREFIX` mechanism

### Files Changed
2 files changed, 14 insertions(+), 14 deletions(-)