### PR TITLE
ci: move verify-package step from workflow to Makefile

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -163,18 +163,10 @@ jobs:
 
       - name: Verify Package
         run: |
-          set -euo pipefail
-          TARBALL="dist/sqlite-${{ matrix.platform }}-${{ matrix.process-mode }}.tar.bz2"
-          if [[ ! -f "$TARBALL" ]]; then
-            echo "::error::Package tarball not found: $TARBALL"
-            exit 1
-          fi
-          echo "Package contents:"
-          tar tjf "$TARBALL"
-          if ! (set +o pipefail; tar tjf "$TARBALL" | grep -q 'sysroot/lib/'); then
-            echo "::error::Package missing sysroot/lib/ entries"
-            exit 1
-          fi
+          make -f Makefile.nanvix CONFIG_NANVIX=y \
+            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
+            PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
+            verify-package
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
@@ -270,13 +262,14 @@ jobs:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           ZLIB_TAG: ${{ steps.deps.outputs.zlib_tag }}
         run: |
+          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
           echo "Triggering cpython workflow..."
           gh api repos/nanvix/cpython/dispatches \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -f event_type="sqlite-release" \
             -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
-            -f "client_payload[sqlite_tag]=${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}" \
+            -f "client_payload[sqlite_tag]=${RELEASE_TAG}" \
             -f "client_payload[zlib_tag]=${ZLIB_TAG}" || echo "::warning::Failed to trigger cpython workflow"
 
   report-failure:

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -257,6 +257,24 @@ endif
 	@tar tjf dist/$(ARTIFACT_NAME).tar.bz2 | head -20
 
 # ===========================================================================
+# Verify Package
+# ===========================================================================
+
+verify-package:
+	@echo "=== Verifying SQLite package ==="
+	$(eval ARTIFACT_NAME := sqlite-$(PLATFORM)-$(PROCESS_MODE))
+	@TARBALL="dist/$(ARTIFACT_NAME).tar.bz2"; \
+	if [ ! -f "$$TARBALL" ]; then \
+	  echo "FAIL: Package tarball not found: $$TARBALL"; exit 1; \
+	fi; \
+	echo "Package contents:"; \
+	tar tjf "$$TARBALL"; \
+	if ! tar tjf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
+	  echo "FAIL: Package missing sysroot/lib/ entries"; exit 1; \
+	fi; \
+	echo "  PASS: SQLite package verification"
+
+# ===========================================================================
 # Install / Clean
 # ===========================================================================
 
@@ -286,4 +304,4 @@ distclean: clean
 	-make distclean 2>/dev/null || true
 	git clean -fdx -e Makefile.nanvix -e NANVIX.md -e .github -e nanvix-artifacts 2>/dev/null || true
 
-.PHONY: all configure build clean distclean test test-smoke test-integration test-functional package install
+.PHONY: all configure build clean distclean test test-smoke test-integration test-functional package verify-package install


### PR DESCRIPTION
Move the inline package verification logic from `nanvix-ci.yml` into a `verify-package` target in `Makefile.nanvix`.

**Changes:**
- Add `verify-package` target to `Makefile.nanvix` that checks tarball existence, lists contents, and verifies `sysroot/lib/` entries
- Replace inline shell in CI workflow's "Verify Package" step with `make verify-package`
- Use `RELEASE_TAG` variable in "Trigger Dependent Workflows" step for consistency

**Benefits:**
- Package verification is now runnable locally (`make -f Makefile.nanvix ... verify-package`)
- Eliminates duplicated logic between CI workflow and validation script
- Consistent structure across all Layer 1 submodule workflows

**Tested:** `./validate-layer1.sh --docker` and `./validate-layer1.sh` both pass 20/20 with 0 skips.