### PR TITLE
ci: use GITHUB_TOKEN in nanvix workflow dispatch

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -278,7 +278,7 @@ jobs:
       - name: Trigger Dependent Workflows
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZLIB_TAG: ${{ steps.deps.outputs.zlib_tag }}
         run: |
           RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"


### PR DESCRIPTION
This PR standardizes GitHub authentication in nanvix CI workflows by replacing DISPATCH_TOKEN with GITHUB_TOKEN in dispatch steps.