### PR TITLE
ci: use DISPATCH_TOKEN for cross-repo dispatch

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Trigger Dependent Workflows
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           ZLIB_TAG: ${{ steps.deps.outputs.zlib_tag }}
         run: |
           RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"


### PR DESCRIPTION
The `Trigger Dependent Workflows` step uses `secrets.GITHUB_TOKEN` to dispatch `repository_dispatch` events to other repositories. However, `GITHUB_TOKEN` is scoped to the current repository and cannot create dispatch events on other repos, resulting in HTTP 403 errors.

This switches to `secrets.DISPATCH_TOKEN` which has cross-repo permissions, matching the pattern already used by cpython and nanvix/nanvix's publish-release action.

**Evidence from workflow logs (nanvix 0.12.104 release):**
```
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration",...,"status":"403"}
```