### PR TITLE
feat: add standalone microvm release support

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -74,6 +74,8 @@ jobs:
             process-mode: single-process
           - platform: microvm
             process-mode: multi-process
+          - platform: microvm
+            process-mode: standalone
     name: ${{ matrix.platform }}-${{ matrix.process-mode }}
     container:
       image: nanvix/toolchain:latest-minimal
@@ -172,7 +174,8 @@ jobs:
       - name: Functional Tests
         run: |
           timeout --foreground 300 make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-functional
+            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
+            PROCESS_MODE="${{ matrix.process-mode }}" test-functional
 
       - name: Package
         run: |

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -172,6 +172,7 @@ jobs:
             NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-integration
 
       - name: Functional Tests
+        if: matrix.process-mode != 'standalone'
         run: |
           timeout --foreground 300 make -f Makefile.nanvix CONFIG_NANVIX=y \
             NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -198,6 +198,31 @@ test-functional: build
 	@echo "INSERT INTO nanvix_test VALUES(2, 'python');" >> _sqlite_test.sql
 	@echo "SELECT 'SQLITE_TEST_COUNT:', count(*) FROM nanvix_test;" >> _sqlite_test.sql
 	@echo "SELECT 'SQLITE_TEST_ROW:', id, name FROM nanvix_test WHERE id=1;" >> _sqlite_test.sql
+ifeq ($(PROCESS_MODE),standalone)
+ifdef CONFIG_NANVIX_DOCKER
+	@echo "  Running sqlite3$(EXE) via nanvixd.elf standalone (Docker)..."
+	$(DOCKER_RUN_FUNCTIONAL) sh -c '\
+	  mkdir -p /tmp/nanvix-ramfs && \
+	  cp $(DOCKER_WORKSPACE_PATH)/sqlite3$(EXE) /tmp/nanvix-ramfs/ && \
+	  cp $(DOCKER_WORKSPACE_PATH)/_sqlite_test.sql /tmp/nanvix-ramfs/ && \
+	  ./bin/mkramfs.elf -o /tmp/rootfs.img /tmp/nanvix-ramfs/ && \
+	  timeout --foreground 120 ./bin/nanvixd.elf \
+	    -bin-dir ./bin -ramfs /tmp/rootfs.img \
+	    -- ./sqlite3$(EXE) < $(DOCKER_WORKSPACE_PATH)/_sqlite_test.sql'
+	@echo "  PASS: sqlite3 standalone (exit code 0)"
+else
+	@echo "  Running sqlite3$(EXE) via nanvixd.elf standalone..."
+	@rm -rf /tmp/nanvix-ramfs && mkdir -p /tmp/nanvix-ramfs
+	@cp $(abspath sqlite3$(EXE)) /tmp/nanvix-ramfs/
+	@cp $(abspath _sqlite_test.sql) /tmp/nanvix-ramfs/
+	"$(SYSROOT_PATH)/bin/mkramfs.elf" -o /tmp/rootfs.img /tmp/nanvix-ramfs/
+	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd.elf \
+	  -bin-dir ./bin -ramfs /tmp/rootfs.img \
+	  -- ./sqlite3$(EXE) < $(abspath _sqlite_test.sql)
+	@rm -rf /tmp/nanvix-ramfs /tmp/rootfs.img
+	@echo "  PASS: sqlite3 standalone (exit code 0)"
+endif
+else
 ifdef CONFIG_NANVIX_DOCKER
 	@echo "  Running sqlite3$(EXE) via nanvixd.elf (Docker)..."
 	$(DOCKER_RUN_FUNCTIONAL) sh -c \
@@ -207,6 +232,7 @@ else
 	@echo "  Running sqlite3$(EXE) via nanvixd.elf..."
 	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd.elf -- $(abspath sqlite3$(EXE)) < $(abspath _sqlite_test.sql)
 	@echo "  PASS: sqlite3 (exit code 0)"
+endif
 endif
 	@rm -f _sqlite_test.sql
 	@echo "  PASS: SQLite functional tests"


### PR DESCRIPTION
## Summary

Add standalone microvm release support. Nanvix now releases a standalone artifact for the microvm platform that uses mkramfs to build a ramfs image.

## Changes

- **CI**: Add microvm/standalone as a 5th matrix entry in nanvix-ci.yml
- **Functional tests**: Add standalone branches that use mkramfs + nanvixd -ramfs
- Support both Docker and native toolchain paths

## Testing

- YAML syntax validated across all workflows
- Makefile dry-runs confirm correct standalone vs non-standalone branching
- Non-standalone functional tests remain unaffected (regression-safe)
- Benchmarks show standalone performs comparably to single-process and multi-process