### PR TITLE
Migrate to ZScript build system and CI (z, z.ps1, .nanvix/z.py, nanvix-ci.yml)

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -11,7 +11,7 @@ on:
       - nanvix/**
   workflow_dispatch:
   repository_dispatch:
-    types: [zlib-release]
+    types: [nanvix-minor-release, nanvix-major-release, zlib-release]
 
 permissions:
   contents: write
@@ -23,45 +23,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
 
 jobs:
-  get-nanvix-info:
-    runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.extract.outputs.sha }}
-      sha_full: ${{ steps.extract.outputs.sha_full }}
-    steps:
-      - name: Download Nanvix Release Artifacts
-        id: extract
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Download all Nanvix release artifacts (authenticated to avoid API rate limits)
-          curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- --force nanvix-artifacts
-          # Find any artifact to extract the SHA
-          ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | head -1)
-          if [[ -z "$ARTIFACT_FILE" ]]; then
-            echo "::error::No Nanvix artifact found"
-            exit 1
-          fi
-          # Extract Nanvix commit SHA from artifact filename
-          NANVIX_SHA_FULL=$(basename "$ARTIFACT_FILE" | sed -E 's/.*-([a-f0-9]{40})\.tar\.bz2$/\1/')
-          NANVIX_SHA="${NANVIX_SHA_FULL::7}"
-          echo "Nanvix commit SHA: $NANVIX_SHA_FULL (short: $NANVIX_SHA)"
-          echo "sha=$NANVIX_SHA" >> "$GITHUB_OUTPUT"
-          echo "sha_full=$NANVIX_SHA_FULL" >> "$GITHUB_OUTPUT"
-
-      - name: Upload Nanvix Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: nanvix-release-artifacts
-          path: nanvix-artifacts/*.tar.bz2
-          retention-days: 1
-
   build:
-    needs: get-nanvix-info
     runs-on: ubuntu-latest
-    outputs:
-      zlib_tag: ${{ steps.zlib-dep.outputs.zlib_tag }}
     strategy:
       fail-fast: false
       matrix:
@@ -89,133 +52,95 @@ jobs:
       run:
         shell: bash
     env:
-      NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.sha }}
-      NANVIX_SHA_FULL: ${{ needs.get-nanvix-info.outputs.sha_full }}
+      NANVIX_MACHINE: ${{ matrix.platform }}
+      NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
+      NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
       USER: runner
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Nanvix Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: nanvix-release-artifacts
-          path: nanvix-artifacts
-
-      - name: Extract Nanvix Release
+      - name: Setup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-          # Find and extract the artifact matching platform and process-mode
-          ARTIFACT_PATTERN="${{ matrix.platform }}.*${{ matrix.process-mode }}.*${{ matrix.memory }}.*\.tar\.bz2"
-          ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | grep -E "$ARTIFACT_PATTERN" | head -1)
-          if [[ -z "$ARTIFACT_FILE" ]]; then
-            echo "::error::No ${{ matrix.platform }} ${{ matrix.process-mode }} artifact found"
-            exit 1
-          fi
-          mkdir -p nanvix-artifacts/extracted
-          tar -xjf "$ARTIFACT_FILE" -C nanvix-artifacts/extracted
-          NANVIX_HOME=$(find nanvix-artifacts/extracted -maxdepth 2 -type d -name "bin" -exec dirname {} \; | head -1)
-          mkdir -p "$NANVIX_HOME/include"
-          echo "NANVIX_HOME=$NANVIX_HOME" >> "$GITHUB_ENV"
+          curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages
+          ./z setup
 
-      - name: Download and Install zlib Dependency
-        id: zlib-dep
+      - name: Install zlib dependency
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          ZLIB_ARTIFACT="zlib-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}.tar.bz2"
-          mkdir -p zlib-dep
+          SYSROOT=$(python3 -c "import json; print(json.load(open('.nanvix/env.json'))['NANVIX_SYSROOT'])")
 
-          # Find zlib release built with matching Nanvix SHA
-          ZLIB_RELEASES=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-            "https://api.github.com/repos/nanvix/zlib/releases?per_page=50" 2>/dev/null || echo "[]")
-          MATCHING_RELEASE_TAG=""
-          for tag in $(echo "$ZLIB_RELEASES" | jq -r '.[].tag_name' 2>/dev/null); do
-            if [[ "$tag" == *"-nanvix-${NANVIX_SHA}" ]]; then
-              MATCHING_RELEASE_TAG="$tag"
-              break
-            fi
-          done
-          if [[ -z "$MATCHING_RELEASE_TAG" ]]; then
-            echo "::warning::No zlib release matching Nanvix SHA $NANVIX_SHA, falling back to latest"
-            ZLIB_URL="https://github.com/nanvix/zlib/releases/latest/download/${ZLIB_ARTIFACT}"
-            MATCHING_RELEASE_TAG=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-              "https://api.github.com/repos/nanvix/zlib/releases/latest" 2>/dev/null | jq -r '.tag_name // "latest"')
-          else
-            ZLIB_URL="https://github.com/nanvix/zlib/releases/download/${MATCHING_RELEASE_TAG}/${ZLIB_ARTIFACT}"
-          fi
-          echo "zlib_tag=${MATCHING_RELEASE_TAG}" >> "$GITHUB_OUTPUT"
-
-          if curl -fsSL -o "zlib-dep/${ZLIB_ARTIFACT}" "$ZLIB_URL"; then
-            tar -xjf "zlib-dep/${ZLIB_ARTIFACT}" -C zlib-dep
-            # Handle both sysroot/ and zlib-*/ layouts
-            ZLIB_DIR=$(find zlib-dep -mindepth 1 -maxdepth 1 -type d \( -name "sysroot" -o -name "zlib-*" \) | head -1)
-            if [[ -n "$ZLIB_DIR" ]]; then
-              cp -f "${ZLIB_DIR}/lib/"* "${NANVIX_HOME}/lib/" 2>/dev/null || true
-              cp -f "${ZLIB_DIR}/include/"* "${NANVIX_HOME}/include/" 2>/dev/null || true
-              echo "zlib installed from ${MATCHING_RELEASE_TAG}"
-            fi
-          else
-            echo "::error::Could not download zlib release"
+          # Find the matching zlib release tag for this Nanvix SHA.
+          NANVIX_SHA=$(python3 -c "import json; print(json.load(open('.nanvix/env.json')).get('NANVIX_TAG', 'latest'))")
+          ZLIB_TAG=$(gh api repos/nanvix/zlib/releases --jq '.[0].tag_name' 2>/dev/null || echo "")
+          if [[ -z "$ZLIB_TAG" ]]; then
+            echo "::error::Could not find a zlib release"
             exit 1
           fi
 
+          # Download and extract the matching zlib package.
+          ZLIB_ASSET="zlib-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}.tar.bz2"
+          gh release download "$ZLIB_TAG" \
+            --repo nanvix/zlib \
+            --pattern "$ZLIB_ASSET" \
+            --dir /tmp/zlib-download
+
+          tar -xjf "/tmp/zlib-download/$ZLIB_ASSET" -C /tmp/zlib-extracted 2>/dev/null || {
+            mkdir -p /tmp/zlib-extracted
+            tar -xjf "/tmp/zlib-download/$ZLIB_ASSET" -C /tmp/zlib-extracted
+          }
+
+          # Install zlib into the sysroot.
+          cp -rf /tmp/zlib-extracted/sysroot/* "$SYSROOT/"
+          echo "Installed zlib from $ZLIB_TAG into $SYSROOT"
+          ls -la "$SYSROOT/lib/libz.a"
+
       - name: Build
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            INSTALL_PREFIX="/sysroot" all
+        run: ./z build
 
-      - name: Smoke Tests
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-smoke
-
-      - name: Integration Tests
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-integration
-
-      - name: Functional Tests
+      - name: Test
         if: matrix.process-mode != 'standalone'
-        run: |
-          timeout --foreground 300 make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            PROCESS_MODE="${{ matrix.process-mode }}" test-functional
+        run: ./z test
 
-      - name: Package
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            INSTALL_PREFIX="/sysroot" \
-            PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
-            MEMORY_SIZE="${{ matrix.memory }}" \
-            package
-          ARTIFACT_NAME="sqlite-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}"
-          echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
+      - name: Test (standalone — smoke + integration only)
+        if: matrix.process-mode == 'standalone'
+        run: ./z test -- test-smoke test-integration
 
-      - name: Verify Package
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
-            MEMORY_SIZE="${{ matrix.memory }}" \
-            verify-package
+      - name: Release
+        if: success()
+        run: ./z release
 
       - name: Upload Build Artifacts
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: sqlite-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
-          path: ${{ env.ARTIFACT_TARBALL }}
+          path: dist/*.tar.bz2
           retention-days: 7
 
+      - name: Collect failure logs
+        if: failure()
+        run: |
+          mkdir -p ci-logs
+          cp -f /tmp/*.log ci-logs/ 2>/dev/null || true
+          find .nanvix -type f -name "*.log" -exec cp -f {} ci-logs/ \; 2>/dev/null || true
+          ls -lah ci-logs || true
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-logs-${{ matrix.platform }}-${{ matrix.process-mode }}
+          path: ci-logs/*
+          if-no-files-found: warn
+
   release:
-    needs: [get-nanvix-info, build]
+    needs: [build]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    env:
-      NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.sha }}
-      NANVIX_SHA_FULL: ${{ needs.get-nanvix-info.outputs.sha_full }}
     steps:
       - uses: actions/checkout@v4
 
@@ -232,32 +157,49 @@ jobs:
           find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \;
           ls -la release-assets/
 
-      - name: Get Dependency Tags
-        id: deps
-        env:
-          ZLIB_TAG: ${{ needs.build.outputs.zlib_tag }}
-        run: |
-          echo "zlib_tag=${ZLIB_TAG}" >> "$GITHUB_OUTPUT"
-
       - name: Get Nanvix Release Info
         id: nanvix-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+
+          # Verify we have release assets.
+          ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
+          if [[ "$ASSET_COUNT" -eq 0 ]]; then
+            echo "::error::No release assets found in release-assets/"
+            exit 1
+          fi
+
+          # Get Nanvix release metadata and SHA from the API.
           API_URL="https://api.github.com/repos/nanvix/nanvix/releases/tags/latest"
           RELEASE_INFO=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$API_URL")
           NANVIX_NAME=$(echo "$RELEASE_INFO" | jq -r '.name // "latest"')
           NANVIX_PUBLISHED=$(echo "$RELEASE_INFO" | jq -r '.published_at')
+          NANVIX_SHA_FULL=$(echo "$RELEASE_INFO" | jq -r '.target_commitish // "unknown"')
+          NANVIX_SHA="${NANVIX_SHA_FULL::7}"
+
           echo "name=${NANVIX_NAME}" >> "$GITHUB_OUTPUT"
           echo "published=${NANVIX_PUBLISHED}" >> "$GITHUB_OUTPUT"
+          echo "sha=${NANVIX_SHA}" >> "$GITHUB_OUTPUT"
+          echo "sha_full=${NANVIX_SHA_FULL}" >> "$GITHUB_OUTPUT"
+
+      - name: Get zlib Release Info
+        id: zlib-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ZLIB_TAG=$(gh api repos/nanvix/zlib/releases --jq '.[0].tag_name' 2>/dev/null || echo "unknown")
+          echo "tag=${ZLIB_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Create Latest Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NANVIX_NAME: ${{ steps.nanvix-release.outputs.name }}
           NANVIX_PUBLISHED: ${{ steps.nanvix-release.outputs.published }}
-          ZLIB_TAG: ${{ steps.deps.outputs.zlib_tag }}
+          NANVIX_SHA: ${{ steps.nanvix-release.outputs.sha }}
+          NANVIX_SHA_FULL: ${{ steps.nanvix-release.outputs.sha_full }}
+          ZLIB_TAG: ${{ steps.zlib-release.outputs.tag }}
         run: |
           RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
           if gh release view "$RELEASE_TAG" &>/dev/null; then
@@ -282,11 +224,10 @@ jobs:
           sysroot/
             lib/libsqlite3.a
             include/sqlite3.h
-            bin/{sqlite3,sqlite3.elf}
+            bin/{sqlite3.elf,speedtest1.elf}
           \`\`\`
 
-          **Dependencies:**
-          - zlib: [\`${ZLIB_TAG}\`](https://github.com/nanvix/zlib/releases/tag/${ZLIB_TAG})" \
+          **Dependencies:** zlib (${ZLIB_TAG})" \
             --latest \
             release-assets/*.tar.bz2
 
@@ -294,17 +235,15 @@ jobs:
         if: success()
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-          ZLIB_TAG: ${{ steps.deps.outputs.zlib_tag }}
         run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
+          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${{ steps.nanvix-release.outputs.sha }}"
           echo "Triggering cpython workflow..."
           gh api repos/nanvix/cpython/dispatches \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -f event_type="sqlite-release" \
-            -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
-            -f "client_payload[sqlite_tag]=${RELEASE_TAG}" \
-            -f "client_payload[zlib_tag]=${ZLIB_TAG}" || echo "::warning::Failed to trigger cpython workflow"
+            -f "client_payload[nanvix_sha]=${{ steps.nanvix-release.outputs.sha }}" \
+            -f "client_payload[sqlite_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger cpython workflow"
 
   report-failure:
     needs: [build]

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages
+          apt-get update -qq && apt-get install -y -qq python3-pip
           ./z setup
 
       - name: Install zlib dependency

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,14 @@
 .nanvix-configured
 nanvix-artifacts/
 
+# Nanvix build state (keep .nanvix/z.py tracked)
+.nanvix/venv/
+.nanvix/env.json
+.nanvix/cache/
+.nanvix/sysroot/
+.nanvix/buildroot/
+.nanvix/__pycache__/
+
 # SQLite build artifacts
 .main.mk.checks
 .target_source

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ src-verify
 
 # Temp directories
 tsrc/
+
+# Release artifacts
+dist/

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,7 +11,7 @@ Usage (from repository root):
     ./z clean      # Remove build artifacts
 """
 
-from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, Sysroot, ZScript, log
+from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, EXIT_MISSING_DEP, Sysroot, ZScript, log
 
 
 class SqliteBuild(ZScript):
@@ -26,7 +26,7 @@ class SqliteBuild(ZScript):
         if not nanvix_sysroot:
             log.fatal(
                 f"{CFG_SYSROOT} is not set.",
-                code=3,
+                code=EXIT_MISSING_DEP,
                 hint="Run `./z setup` first to download the sysroot.",
             )
 

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -18,7 +18,7 @@ class SqliteBuild(ZScript):
     """Build script for nanvix/sqlite."""
 
     # SQLite links against zlib — require it in the sysroot.
-    SYSROOT_REQUIRED_FILES = ("lib/libposix.a", "lib/libz.a")
+    SYSROOT_REQUIRED_FILES = ZScript.SYSROOT_REQUIRED_FILES + ("lib/libz.a",)
 
     def _make(self, *targets: str, extra_vars: dict[str, str] | None = None) -> None:
         """Run ``make -f Makefile.nanvix`` with standard Nanvix variables."""

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -17,11 +17,14 @@ from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, EXIT_MISSING_DEP, Sysroot, Z
 class SqliteBuild(ZScript):
     """Build script for nanvix/sqlite."""
 
-    # SQLite links against zlib — require it in the sysroot.
-    SYSROOT_REQUIRED_FILES = ZScript.SYSROOT_REQUIRED_FILES + ("lib/libz.a",)
+    def sysroot_required_files(self) -> list[str]:
+        """Require zlib in addition to the base sysroot files."""
+        files = super().sysroot_required_files()
+        files.append("lib/libz.a")
+        return files
 
-    def _make(self, *targets: str, extra_vars: dict[str, str] | None = None) -> None:
-        """Run ``make -f Makefile.nanvix`` with standard Nanvix variables."""
+    def _make_args(self, *targets: str) -> list[str]:
+        """Build the ``make -f Makefile.nanvix`` argument list."""
         nanvix_sysroot = self.config.get(CFG_SYSROOT, "")
         if not nanvix_sysroot:
             log.fatal(
@@ -30,18 +33,18 @@ class SqliteBuild(ZScript):
                 hint="Run `./z setup` first to download the sysroot.",
             )
 
-        cmd: list[str] = [
+        return [
             "make",
             "-f",
             "Makefile.nanvix",
-            f"CONFIG_NANVIX=y",
+            "CONFIG_NANVIX=y",
             f"NANVIX_HOME={nanvix_sysroot}",
+            *targets,
         ]
-        if extra_vars:
-            for key, val in extra_vars.items():
-                cmd.append(f"{key}={val}")
-        cmd.extend(targets)
-        self.run(*cmd, cwd=self.repo_root)
+
+    def _make(self, *targets: str) -> None:
+        """Run ``make -f Makefile.nanvix`` with standard Nanvix variables."""
+        self.run(*self._make_args(*targets), cwd=self.repo_root)
 
     def setup(self) -> None:
         """Download the Nanvix sysroot and persist its path."""
@@ -52,7 +55,7 @@ class SqliteBuild(ZScript):
             tag="latest",
             gh_token=self.config.get(CFG_GH_TOKEN),
         )
-        sysroot.verify(list(self.SYSROOT_REQUIRED_FILES))
+        sysroot.verify(self.sysroot_required_files())
         self.config.set(CFG_SYSROOT, str(sysroot.path))
         self.config.save()
 
@@ -61,23 +64,19 @@ class SqliteBuild(ZScript):
         self._make("all")
 
     def test(self) -> None:
-        """Run smoke, integration, and functional tests."""
-        platform_vars = {
-            "PLATFORM": self.config.machine,
-            "PROCESS_MODE": self.config.deployment_mode,
-            "MEMORY_SIZE": self.config.memory_size,
-        }
-        self._make("test", extra_vars=platform_vars)
+        """Run the SQLite test suite.
+
+        Without targets, runs the full suite (smoke + integration + functional).
+        With targets (e.g. ``./z test -- test-smoke test-integration``), passes
+        them directly to the Makefile.
+        """
+        targets = self.targets if self.targets else ["test"]
+        self.run(*self._make_args(*targets), cwd=self.repo_root)
 
     def release(self) -> None:
-        """Package the release tarball and verify it."""
-        platform_vars = {
-            "PLATFORM": self.config.machine,
-            "PROCESS_MODE": self.config.deployment_mode,
-            "MEMORY_SIZE": self.config.memory_size,
-        }
-        self._make("package", extra_vars=platform_vars)
-        self._make("verify-package", extra_vars=platform_vars)
+        """Package the SQLite release tarball and verify it."""
+        self.run(*self._make_args("package"), cwd=self.repo_root)
+        self.run(*self._make_args("verify-package"), cwd=self.repo_root)
 
     def clean(self) -> None:
         """Remove build artifacts."""

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -1,0 +1,88 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Nanvix build script for sqlite.
+
+Usage (from repository root):
+    ./z setup      # Download sysroot
+    ./z build      # Build libsqlite3.a and sqlite3.elf
+    ./z test       # Run smoke, integration, and functional tests
+    ./z release    # Package release tarball
+    ./z clean      # Remove build artifacts
+"""
+
+from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, Sysroot, ZScript, log
+
+
+class SqliteBuild(ZScript):
+    """Build script for nanvix/sqlite."""
+
+    # SQLite links against zlib — require it in the sysroot.
+    SYSROOT_REQUIRED_FILES = ("lib/libposix.a", "lib/libz.a")
+
+    def _make(self, *targets: str, extra_vars: dict[str, str] | None = None) -> None:
+        """Run ``make -f Makefile.nanvix`` with standard Nanvix variables."""
+        nanvix_sysroot = self.config.get(CFG_SYSROOT, "")
+        if not nanvix_sysroot:
+            log.fatal(
+                f"{CFG_SYSROOT} is not set.",
+                code=3,
+                hint="Run `./z setup` first to download the sysroot.",
+            )
+
+        cmd: list[str] = [
+            "make",
+            "-f",
+            "Makefile.nanvix",
+            f"CONFIG_NANVIX=y",
+            f"NANVIX_HOME={nanvix_sysroot}",
+        ]
+        if extra_vars:
+            for key, val in extra_vars.items():
+                cmd.append(f"{key}={val}")
+        cmd.extend(targets)
+        self.run(*cmd, cwd=self.repo_root)
+
+    def setup(self) -> None:
+        """Download the Nanvix sysroot and persist its path."""
+        sysroot = Sysroot.download(
+            machine=self.config.machine,
+            deployment_mode=self.config.deployment_mode,
+            memory_size=self.config.memory_size,
+            tag="latest",
+            gh_token=self.config.get(CFG_GH_TOKEN),
+        )
+        sysroot.verify(list(self.SYSROOT_REQUIRED_FILES))
+        self.config.set(CFG_SYSROOT, str(sysroot.path))
+        self.config.save()
+
+    def build(self) -> None:
+        """Build libsqlite3.a and sqlite3.elf."""
+        self._make("all")
+
+    def test(self) -> None:
+        """Run smoke, integration, and functional tests."""
+        platform_vars = {
+            "PLATFORM": self.config.machine,
+            "PROCESS_MODE": self.config.deployment_mode,
+            "MEMORY_SIZE": self.config.memory_size,
+        }
+        self._make("test", extra_vars=platform_vars)
+
+    def release(self) -> None:
+        """Package the release tarball and verify it."""
+        platform_vars = {
+            "PLATFORM": self.config.machine,
+            "PROCESS_MODE": self.config.deployment_mode,
+            "MEMORY_SIZE": self.config.memory_size,
+        }
+        self._make("package", extra_vars=platform_vars)
+        self._make("verify-package", extra_vars=platform_vars)
+
+    def clean(self) -> None:
+        """Remove build artifacts."""
+        self.run("make", "-f", "Makefile.nanvix", "clean", cwd=self.repo_root)
+
+
+if __name__ == "__main__":
+    SqliteBuild.main()

--- a/z
+++ b/z
@@ -12,9 +12,9 @@ MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.1.1"
+ZUTIL_TAG="v0.2.0"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:d22dffb2e4efd8d4514edd8101ea74f496aea4b6b7bde1c972dce799f230a881"
+ZUTIL_HASH="sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
 
 # Locate a suitable Python interpreter.
 find_python() {

--- a/z
+++ b/z
@@ -12,9 +12,9 @@ MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.1.0"
+ZUTIL_TAG="v0.1.1"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:120d9bb4e409cf75ce823237812a414cd4ca90be8c421cad0c3583889a097497"
+ZUTIL_HASH="sha256:d22dffb2e4efd8d4514edd8101ea74f496aea4b6b7bde1c972dce799f230a881"
 
 # Locate a suitable Python interpreter.
 find_python() {
@@ -70,7 +70,13 @@ PYTHON=$(find_python) || {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
 VENV_DIR="${SCRIPT_DIR}/.nanvix/venv"
-VENV_PYTHON="${VENV_DIR}/bin/python"
+
+# Detect venv interpreter path (Scripts/python.exe on Windows/MSYS).
+if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
+    VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
+else
+    VENV_PYTHON="${VENV_DIR}/bin/python"
+fi
 
 if [[ ! -f "${Z_SCRIPT}" ]]; then
     echo "error: ${Z_SCRIPT} not found." >&2
@@ -83,6 +89,11 @@ if [[ ! -f "${VENV_PYTHON}" ]]; then
     echo "bootstrap: creating venv …" >&2
     run_python -m venv "${VENV_DIR}"
 
+    # Re-detect after venv creation.
+    if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
+        VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
+    fi
+
     if [[ -n "${NANVIX_ZUTIL_PATH:-}" ]]; then
         echo "bootstrap: installing nanvix-zutil (editable) …" >&2
         "${VENV_PYTHON}" -m pip install -q -e "${NANVIX_ZUTIL_PATH}"
@@ -93,9 +104,11 @@ if [[ ! -f "${VENV_PYTHON}" ]]; then
         whl_url="${ZUTIL_RELEASE_BASE}/${ZUTIL_TAG}/${whl_name}"
         echo "bootstrap: installing nanvix-zutil (${ZUTIL_TAG}) …" >&2
         tmp_req=$(mktemp)
+        trap 'rm -f "${tmp_req}"' EXIT
         echo "nanvix_zutil @ ${whl_url} --hash=${ZUTIL_HASH}" > "${tmp_req}"
         "${VENV_PYTHON}" -m pip install -q --require-hashes -r "${tmp_req}"
         rm -f "${tmp_req}"
+        trap - EXIT
     fi
 fi
 

--- a/z
+++ b/z
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Bootstrap wrapper for Nanvix build scripts.
+# Modeled on https://github.com/rust-lang/rust/blob/main/x
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+# Minimum required Python version.
+MIN_PYTHON_MAJOR=3
+MIN_PYTHON_MINOR=12
+
+# nanvix-zutil release to install in the project venv.
+ZUTIL_TAG="v0.1.0"
+ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
+ZUTIL_HASH="sha256:120d9bb4e409cf75ce823237812a414cd4ca90be8c421cad0c3583889a097497"
+
+# Locate a suitable Python interpreter.
+find_python() {
+    # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
+    # then fall back to generic names.
+    local candidates=()
+    local minor
+    for ((minor=20; minor>=MIN_PYTHON_MINOR; minor--)); do
+        candidates+=("python3.${minor}")
+    done
+    candidates+=("python3" "python" "py")
+    for candidate in "${candidates[@]}"; do
+        if command -v "${candidate}" &>/dev/null; then
+            local version
+            if [[ "${candidate}" == "py" ]]; then
+                version=$("${candidate}" -3 -c \
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
+                    2>/dev/null) || continue
+            else
+                version=$("${candidate}" -c \
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
+                    2>/dev/null) || continue
+            fi
+            local major minor
+            major=$(echo "${version}" | tr -d '\r' | cut -d. -f1)
+            minor=$(echo "${version}" | tr -d '\r' | cut -d. -f2)
+            if [[ "${major}" -gt "${MIN_PYTHON_MAJOR}" ]] || \
+               [[ "${major}" -eq "${MIN_PYTHON_MAJOR}" && "${minor}" -ge "${MIN_PYTHON_MINOR}" ]]; then
+                echo "${candidate}"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+# Run the discovered Python interpreter (handles 'py -3' on Windows).
+run_python() {
+    if [[ "${PYTHON}" == "py" ]]; then
+        "${PYTHON}" -3 "$@"
+    else
+        "${PYTHON}" "$@"
+    fi
+}
+
+PYTHON=$(find_python) || {
+    echo "error: Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ not found in PATH." >&2
+    echo "hint:  Install Python 3.12+ and ensure it is on your PATH." >&2
+    exit 3
+}
+
+# Resolve the directory containing this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
+VENV_DIR="${SCRIPT_DIR}/.nanvix/venv"
+VENV_PYTHON="${VENV_DIR}/bin/python"
+
+if [[ ! -f "${Z_SCRIPT}" ]]; then
+    echo "error: ${Z_SCRIPT} not found." >&2
+    echo "hint:  Create .nanvix/z.py with a ZScript subclass." >&2
+    exit 3
+fi
+
+# Bootstrap: create venv and install nanvix-zutil if needed.
+if [[ ! -f "${VENV_PYTHON}" ]]; then
+    echo "bootstrap: creating venv …" >&2
+    run_python -m venv "${VENV_DIR}"
+
+    if [[ -n "${NANVIX_ZUTIL_PATH:-}" ]]; then
+        echo "bootstrap: installing nanvix-zutil (editable) …" >&2
+        "${VENV_PYTHON}" -m pip install -q -e "${NANVIX_ZUTIL_PATH}"
+    else
+        version="${ZUTIL_TAG#v}"
+        version="${version//-/}"
+        whl_name="nanvix_zutil-${version}-py3-none-any.whl"
+        whl_url="${ZUTIL_RELEASE_BASE}/${ZUTIL_TAG}/${whl_name}"
+        echo "bootstrap: installing nanvix-zutil (${ZUTIL_TAG}) …" >&2
+        tmp_req=$(mktemp)
+        echo "nanvix_zutil @ ${whl_url} --hash=${ZUTIL_HASH}" > "${tmp_req}"
+        "${VENV_PYTHON}" -m pip install -q --require-hashes -r "${tmp_req}"
+        rm -f "${tmp_req}"
+    fi
+fi
+
+exec "${VENV_PYTHON}" "${Z_SCRIPT}" "$@"

--- a/z
+++ b/z
@@ -12,9 +12,9 @@ MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.2.0"
+ZUTIL_TAG="v0.2.2"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
+ZUTIL_HASH="sha256:dc28bb5b83fe0afebb89a3b02b334d4753ba362328d5b4f32f79c2cb8df6ba8a"
 
 # Locate a suitable Python interpreter.
 find_python() {

--- a/z.ps1
+++ b/z.ps1
@@ -16,9 +16,9 @@ $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.1.0"
+$ZUTIL_TAG = "v0.1.1"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:120d9bb4e409cf75ce823237812a414cd4ca90be8c421cad0c3583889a097497"
+$ZUTIL_HASH = "sha256:d22dffb2e4efd8d4514edd8101ea74f496aea4b6b7bde1c972dce799f230a881"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
@@ -27,17 +27,13 @@ function Find-Python {
     for ($minor = 20; $minor -ge $MIN_MINOR; $minor--) {
         $candidates += "python3.$minor"
     }
-    $candidates += @("py", "python3", "python")
+    $candidates += @("python3", "python")
     foreach ($candidate in $candidates) {
         $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
         if ($null -eq $cmd) { continue }
 
-        # For 'py', pass -3 to select Python 3.
-        $pyArgs = if ($candidate -eq "py") { @("-3", "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") } `
-                  else { @("-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") }
-
         try {
-            $version = & $candidate @pyArgs 2>$null
+            $version = & $candidate -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
             if ($LASTEXITCODE -ne 0) { continue }
             $parts = $version.Trim().Split(".")
             $major = [int]$parts[0]
@@ -49,17 +45,29 @@ function Find-Python {
             continue
         }
     }
+
+    # Windows 'py' launcher: probe specific minor versions (high to low).
+    $pyCmd = Get-Command "py" -ErrorAction SilentlyContinue
+    if ($null -ne $pyCmd) {
+        for ($minor = 20; $minor -ge $MIN_MINOR; $minor--) {
+            try {
+                $exe = & py "-3.$minor" -c "import sys; print(sys.executable)" 2>$null
+                if ($LASTEXITCODE -eq 0 -and $exe) {
+                    return $exe.Trim()
+                }
+            } catch {
+                continue
+            }
+        }
+    }
+
     return $null
 }
 
-# Run the discovered Python interpreter (handles 'py -3' on Windows).
+# Run the discovered Python interpreter.
 function Invoke-Python {
     param([Parameter(ValueFromRemainingArguments)] [string[]]$Args_)
-    if ($python -eq "py") {
-        & $python -3 @Args_
-    } else {
-        & $python @Args_
-    }
+    & $python @Args_
 }
 
 $python = Find-Python

--- a/z.ps1
+++ b/z.ps1
@@ -16,9 +16,9 @@ $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.1.1"
+$ZUTIL_TAG = "v0.2.0"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:d22dffb2e4efd8d4514edd8101ea74f496aea4b6b7bde1c972dce799f230a881"
+$ZUTIL_HASH = "sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,

--- a/z.ps1
+++ b/z.ps1
@@ -1,0 +1,112 @@
+# Bootstrap wrapper for Nanvix build scripts.
+# Modeled on https://github.com/rust-lang/rust/blob/main/x.ps1
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# If script execution is disabled, run:
+#   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$MIN_MAJOR = 3
+$MIN_MINOR = 12
+
+# nanvix-zutil release to install in the project venv.
+$ZUTIL_TAG = "v0.1.0"
+$ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
+$ZUTIL_HASH = "sha256:120d9bb4e409cf75ce823237812a414cd4ca90be8c421cad0c3583889a097497"
+
+function Find-Python {
+    # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
+    # then fall back to generic names.
+    $candidates = @()
+    for ($minor = 20; $minor -ge $MIN_MINOR; $minor--) {
+        $candidates += "python3.$minor"
+    }
+    $candidates += @("py", "python3", "python")
+    foreach ($candidate in $candidates) {
+        $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -eq $cmd) { continue }
+
+        # For 'py', pass -3 to select Python 3.
+        $pyArgs = if ($candidate -eq "py") { @("-3", "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") } `
+                  else { @("-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") }
+
+        try {
+            $version = & $candidate @pyArgs 2>$null
+            if ($LASTEXITCODE -ne 0) { continue }
+            $parts = $version.Trim().Split(".")
+            $major = [int]$parts[0]
+            $minor = [int]$parts[1]
+            if ($major -gt $MIN_MAJOR -or ($major -eq $MIN_MAJOR -and $minor -ge $MIN_MINOR)) {
+                return $candidate
+            }
+        } catch {
+            continue
+        }
+    }
+    return $null
+}
+
+# Run the discovered Python interpreter (handles 'py -3' on Windows).
+function Invoke-Python {
+    param([Parameter(ValueFromRemainingArguments)] [string[]]$Args_)
+    if ($python -eq "py") {
+        & $python -3 @Args_
+    } else {
+        & $python @Args_
+    }
+}
+
+$python = Find-Python
+if ($null -eq $python) {
+    Write-Warning "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH."
+    Write-Host "hint:  Install Python 3.12+ and ensure it is on your PATH." -ForegroundColor Yellow
+    exit 3
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$zScript = Join-Path $scriptDir ".nanvix" "z.py"
+$venvDir = Join-Path $scriptDir ".nanvix" "venv"
+if ($IsWindows) {
+    $venvPython = Join-Path $venvDir "Scripts" "python.exe"
+} else {
+    $venvPython = Join-Path $venvDir "bin" "python"
+}
+
+if (-not (Test-Path $zScript)) {
+    Write-Warning "error: $zScript not found."
+    Write-Host "hint:  Create .nanvix/z.py with a ZScript subclass." -ForegroundColor Yellow
+    exit 3
+}
+
+# Bootstrap: create venv and install nanvix-zutil if needed.
+if (-not (Test-Path $venvPython)) {
+    Write-Host "bootstrap: creating venv …" -ForegroundColor Cyan
+    Invoke-Python -m venv $venvDir
+
+    $zutilPath = $env:NANVIX_ZUTIL_PATH
+    if ($zutilPath) {
+        Write-Host "bootstrap: installing nanvix-zutil (editable) …" -ForegroundColor Cyan
+        & $venvPython -m pip install -q -e $zutilPath
+    } else {
+        $version = $ZUTIL_TAG.TrimStart("v").Replace("-", "")
+        $whlName = "nanvix_zutil-${version}-py3-none-any.whl"
+        $whlUrl = "${ZUTIL_RELEASE_BASE}/${ZUTIL_TAG}/${whlName}"
+        Write-Host "bootstrap: installing nanvix-zutil ($ZUTIL_TAG) …" -ForegroundColor Cyan
+        $tmpReq = [System.IO.Path]::GetTempFileName()
+        Set-Content -Path $tmpReq -Value "nanvix_zutil @ $whlUrl --hash=$ZUTIL_HASH"
+        try {
+            & $venvPython -m pip install -q --require-hashes -r $tmpReq
+        } finally {
+            Remove-Item -Path $tmpReq -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+& $venvPython $zScript @args
+exit $LASTEXITCODE

--- a/z.ps1
+++ b/z.ps1
@@ -16,9 +16,9 @@ $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.2.0"
+$ZUTIL_TAG = "v0.2.2"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
+$ZUTIL_HASH = "sha256:dc28bb5b83fe0afebb89a3b02b334d4753ba362328d5b4f32f79c2cb8df6ba8a"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,


### PR DESCRIPTION
Add Python-based z build script wrapping Makefile.nanvix targets, following the established pattern from bzip2/zlib repos.

**New files:**
- `z` — Bash bootstrap (finds Python 3.12+, creates venv, installs nanvix-zutil v0.1.0)
- `z.ps1` — PowerShell bootstrap (Windows equivalent)
- `.nanvix/z.py` — `SqliteBuild(ZScript)` with setup/build/test/release/clean hooks
- `.gitignore` — excludes `.nanvix/` runtime state (venv, env.json, cache, sysroot)

SQLite's `SYSROOT_REQUIRED_FILES` includes `lib/libz.a` since it links against zlib.

No changes to `Makefile.nanvix` or CI workflows.