### PR TITLE
ci: deduplicate failure issues and add second assignee

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -313,7 +313,7 @@ jobs:
           needs.release.result == 'failure' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Create failure issue
+      - name: Report failure issue
         uses: actions/github-script@v7
         env:
           BUILD_RESULT: ${{ needs.build.result }}
@@ -321,10 +321,35 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `CI failure (run ${context.runNumber})`,
-              body: `The SQLite CI workflow failed.\n- Trigger: ${context.eventName}\n- Run: [#${context.runNumber}](${runUrl})\n- SHA: ${context.sha}\n- build: ${process.env.BUILD_RESULT}\n\nPlease investigate.`,
-              assignees: ['ppenna']
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = `CI failure`;
+            const body = [
+              `The SQLite CI workflow failed.`,
+              `- Trigger: ${context.eventName}`,
+              `- Run: [#${context.runNumber}](${runUrl})`,
+              `- SHA: ${context.sha}`,
+              `- build: ${process.env.BUILD_RESULT}`,
+              '',
+              'Please investigate and take any corrective actions.'
+            ].join('\n');
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
             });
+            const existing = issues.find(i => i.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: existing.number, body });
+              const currentAssignees = existing.assignees.map(a => a.login);
+              const desired = ['ppenna', 'danbugs'];
+              const missing = desired.filter(a => !currentAssignees.includes(a));
+              if (missing.length > 0) {
+                await github.rest.issues.addAssignees({ owner, repo, issue_number: existing.number, assignees: missing });
+              }
+            } else {
+              await github.rest.issues.create({ owner, repo, title, body, assignees: ['ppenna', 'danbugs'] });
+            }

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -334,13 +334,10 @@ jobs:
               'Please investigate and take any corrective actions.'
             ].join('\n');
 
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              per_page: 100
+            const { data: search } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue is:open in:title "CI failure"`
             });
-            const existing = issues.find(i => i.title === title);
+            const existing = search.items.find(i => i.title === title);
 
             if (existing) {
               await github.rest.issues.createComment({ owner, repo, issue_number: existing.number, body });


### PR DESCRIPTION
## Summary

Updates the `report-failure` job in `nanvix-ci.yml` to:

1. **Deduplicate failure issues** — searches for an existing open issue titled `CI failure` before creating a new one. If found, adds a comment with the run-specific details instead of opening a duplicate.
2. **Assign both `ppenna` and `danbugs`** — previously only `ppenna` was assigned. When commenting on an existing issue, any missing assignees are added automatically.

## Changes

- Replaced the `github-script` in the `report-failure` job
- Step renamed from *Create failure issue* to *Report failure issue*
- `needs`, `if`, and `env` blocks are unchanged