### PR TITLE
[ci] Stagger nightly schedule for dependency ordering

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -5,7 +5,7 @@ name: Nanvix CI
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 10 * * *"
   push:
     branches: ["nanvix/**"]
   pull_request:


### PR DESCRIPTION
## Summary

Stagger the nightly CI schedule so dependency levels build in order, ensuring upstream releases are published before dependents try to resolve them.

### Schedule

| Level | Repos | PST | UTC |
|-------|-------|-----|-----|
| nanvix/nanvix | core | — | 00:00 (existing) |
| 0 (leaf libs) | zlib, bzip2, libffi, openssl, quickjs | 01:00 | 09:00 |
| **1** | **sqlite (depends on zlib)** | **02:00** | **10:00** |
| 2 | cpython (depends on all above) | 03:00 | 11:00 |

### Problem

All `@usr/` repos previously ran at 00:00 UTC simultaneously. When `nanvix-zutil resolve` fetched a new nanvix version, dependent repos (sqlite, cpython) would try to download upstream releases (zlib, sqlite) that had not been published yet, causing 404 errors and stale releases.

### Change

Single-line cron time change in `.github/workflows/nanvix-ci.yml`.