### PR TITLE
[ci] E: Temporarily set schedule to 9:30 AM PST

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -5,7 +5,7 @@ name: Nanvix CI
 
 on:
   schedule:
-    - cron: "0 10 * * *"
+    - cron: "30 17 * * *"
   push:
     branches: ["nanvix/**"]
   pull_request:


### PR DESCRIPTION
Temporary cron change to `30 17 * * *` (9:30 AM PST / 17:30 UTC) to validate the scheduled CI fix without waiting for the nightly run.

**This should be reverted after validation.**