### PR TITLE
[ci] E: Restore original schedule and keep dispatch support

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -5,7 +5,7 @@ name: Nanvix CI
 
 on:
   schedule:
-    - cron: "50 16 * * *"
+    - cron: "0 10 * * *"
   push:
     branches: ["nanvix/**"]
   pull_request:


### PR DESCRIPTION
Reverts the temporary cron schedule back to the original while keeping `workflow_dispatch` routed to the `ci-scheduled` job.

**Net changes from the original workflow (before this investigation):**
- Split `ci` into `ci` (push/PR) and `ci-scheduled` (schedule/dispatch) for least-privilege
- Added `pull-requests: write` at workflow and job level (required for `update-nanvix-version` PR creation)
- Bumped reusable workflow from `v1.4.0` to `v1.5.0` (includes `pull-requests: write` in reusable workflow permissions — needed for caller-callee permission intersection)
- `workflow_dispatch` routes to `ci-scheduled` so the schedule path can be tested manually