### PR TITLE
ci: disable hyperlight single-process and multi-process

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       zutil-version: "v0.7.25"
       memory-sizes: '["128mb","256mb"]'
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
       caller-event-name: ${{ github.event_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -45,6 +46,7 @@ jobs:
     with:
       zutil-version: "v0.7.25"
       memory-sizes: '["128mb","256mb"]'
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
       caller-event-name: 'schedule'
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Exclude hyperlight+single-process and hyperlight+multi-process combinations from the CI build matrix via `matrix-exclude` in both the `ci` and `ci-scheduled` jobs.

This is a workaround to disable hyperlight single-process and multi-process modes in CI.