### PR TITLE
ci: adopt docker-build / native-test workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,6 +30,7 @@ jobs:
       zutil-version: "v0.7.26"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: ${{ github.event_name }}
+      windows-test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -46,6 +47,7 @@ jobs:
       zutil-version: "v0.7.26"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: 'schedule'
+      windows-test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary
Adopt the new docker-build / native-test CI workflow (v1.12.0).

### Changes
- **Workflow**: Update to `nanvix/workflows@v1.12.0`
- **zutil**: Update to `v0.7.26`
- **Windows test**: Enable artifact-based Windows testing on `windows-latest`

### How it works
- **Linux**: Build with Docker, test natively (KVM)
- **Windows**: Download ELF binaries from Linux build, test natively (`nanvixd.exe`)
- All on GitHub-hosted runners (no self-hosted required)