### PR TITLE
chore: bump nanvix-version to 0.12.490

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.12.485"
+nanvix-version = "0.12.490"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Bumps `nanvix-version` from 0.12.485 to 0.12.490 in `.nanvix/nanvix.toml`.