### PR TITLE
fix(.nanvix/z.py): resolve all Python lint issues

### DIFF
--- a/.nanvix/nanvix_zutil.pyi
+++ b/.nanvix/nanvix_zutil.pyi
@@ -1,0 +1,43 @@
+"""Type stub for nanvix_zutil (external, not shipped with this repo)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, NoReturn
+
+CFG_SYSROOT: str
+CFG_TOOLCHAIN: str
+EXIT_MISSING_DEP: int
+
+
+class _Config:
+    machine: str
+    deployment_mode: str
+    memory_size: str
+
+    def get(self, key: str, default: str = "") -> str: ...
+
+
+class _Log:
+    def fatal(
+        self, msg: str, *, code: int = ..., hint: str = ...,
+    ) -> NoReturn: ...
+    def info(self, msg: str) -> None: ...
+    def error(self, msg: str) -> None: ...
+
+
+log: _Log
+
+
+class ZScript:
+    config: _Config
+    repo_root: Path
+    nanvix_dir: Path
+    targets: list[str]
+
+    def translate_path(self, path: Path) -> str: ...
+    def run(self, *args: Any, cwd: Path | None = ...) -> None: ...
+    def setup(self) -> None: ...
+
+    @classmethod
+    def main(cls) -> None: ...

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -12,13 +12,18 @@ Usage:
 """
 
 import shutil
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
-import subprocess
-import sys
-
-from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
+from nanvix_zutil import (  # type: ignore[import-not-found]
+    CFG_SYSROOT,
+    CFG_TOOLCHAIN,
+    EXIT_MISSING_DEP,
+    ZScript,
+    log,
+)
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
@@ -33,14 +38,15 @@ _MAKE_VAR_INSTALL_PREFIX = "INSTALL_PREFIX"
 # Use /sysroot so that release tarballs don't contain ephemeral runner paths.
 _DEFAULT_INSTALL_PREFIX = "/sysroot"
 
-
-
 IS_WINDOWS = sys.platform == "win32"
+
 
 class SqliteBuild(ZScript):
     """Build script for nanvix/sqlite."""
 
-    def _make_args(self, *targets: str, with_install_prefix: bool = True) -> list[str]:
+    def _make_args(
+        self, *targets: str, with_install_prefix: bool = True,
+    ) -> list[str]:
         """Build the common make argument list."""
         sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot:
@@ -67,7 +73,9 @@ class SqliteBuild(ZScript):
         ])
 
         if with_install_prefix:
-            args.append(f"{_MAKE_VAR_INSTALL_PREFIX}={_DEFAULT_INSTALL_PREFIX}")
+            args.append(
+                f"{_MAKE_VAR_INSTALL_PREFIX}={_DEFAULT_INSTALL_PREFIX}",
+            )
 
         args.extend(targets)
         return args
@@ -97,10 +105,15 @@ class SqliteBuild(ZScript):
                 target = dst / item.name
                 if item.is_dir():
                     shutil.copytree(item, target, dirs_exist_ok=True)
-                    log.info(f"Merged directory {subdir}/{item.name} into sysroot")
+                    log.info(
+                        f"Merged directory {subdir}/{item.name}"
+                        " into sysroot",
+                    )
                 elif not target.exists():
                     shutil.copy2(item, target)
-                    log.info(f"Merged {subdir}/{item.name} into sysroot")
+                    log.info(
+                        f"Merged {subdir}/{item.name} into sysroot",
+                    )
 
     def build(self) -> None:
         """Cross-compile libsqlite3.a and sqlite3.elf for Nanvix."""
@@ -109,49 +122,53 @@ class SqliteBuild(ZScript):
     def test(self) -> None:
         """Run the test suite.
 
-        On non-Windows, delegates to the Makefile (smoke + integration + functional).
+        On non-Windows, delegates to the Makefile
+        (smoke + integration + functional).
         On Windows, runs sqlite3.elf via nanvixd.exe in standalone mode,
         piping SQL commands through stdin.
         """
         if IS_WINDOWS:
             self._run_tests_windows()
             return
-        targets = self.targets if self.targets else ["test"]
+        targets = self.targets or ["test"]
         self.run(*self._make_args(*targets), cwd=self.repo_root)
 
-    def _run_tests_windows(self) -> None:
-        """Run tests natively on Windows using nanvixd.exe.
-
-        Only standalone mode is tested on Windows; multi-process and
-        single-process require linuxd, which is Linux-only. The sqlite3.elf
-        binary is discovered in the repository root, where the Makefile emits
-        ELF outputs, rather than under ``build/``.
-        """
-        if self.config.deployment_mode != "standalone":
-            print(f"Skipping tests on Windows for mode '{self.config.deployment_mode}' (requires linuxd).")
-            return
-
-        # --- standalone: full functional test via nanvixd.exe ---
+    def _resolve_windows_tools(self) -> tuple[Path, Path, Path]:
+        """Resolve sysroot path, nanvixd, and mkramfs for Windows tests."""
         sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot:
-            log.fatal(f"{CFG_SYSROOT} is not set.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+            log.fatal(
+                f"{CFG_SYSROOT} is not set.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` first.",
+            )
         sysroot_path = Path(sysroot)
         nanvixd = sysroot_path / "bin" / "nanvixd.exe"
         mkramfs = sysroot_path / "bin" / "mkramfs.exe"
         if not nanvixd.is_file():
-            log.fatal("nanvixd.exe not found.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+            log.fatal(
+                "nanvixd.exe not found.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` first.",
+            )
         if not mkramfs.is_file():
-            log.fatal("mkramfs.exe not found.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+            log.fatal(
+                "mkramfs.exe not found.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` first.",
+            )
+        return sysroot_path, nanvixd, mkramfs
 
-        # The Makefile outputs ELFs directly to the repository root, not to a
-        # build/ subdirectory.  Search the repo root first; fall back to build/
-        # for forward-compatibility in case a future Makefile change moves them.
+    def _find_test_binaries(self) -> list[Path]:
+        """Find allowlisted ELF test binaries in the repo."""
         test_allowlist = {"sqlite3.elf"}
         test_binaries: list[Path] = []
         for candidate in [self.repo_root, self.repo_root / "build"]:
             if candidate.is_dir():
                 elfs = sorted(candidate.glob("*.elf"))
-                found = [b for b in elfs if b.name in test_allowlist]
+                found = [
+                    b for b in elfs if b.name in test_allowlist
+                ]
                 for b in found:
                     if b.name not in {x.name for x in test_binaries}:
                         test_binaries.append(b)
@@ -159,70 +176,145 @@ class SqliteBuild(ZScript):
         if not test_binaries:
             expected = ", ".join(sorted(test_allowlist))
             log.fatal(
-                f"No allowlisted test binaries found. Expected: {expected}.",
+                f"No allowlisted test binaries found."
+                f" Expected: {expected}.",
                 code=EXIT_MISSING_DEP,
-                hint="Build the test binaries first (for example, run `./z build`) and then rerun `./z test`.",
+                hint=(
+                    "Build the test binaries first"
+                    " (for example, run `./z build`)"
+                    " and then rerun `./z test`."
+                ),
+            )
+        return test_binaries
+
+    def _run_single_test(
+        self,
+        binary: Path,
+        nanvixd: Path,
+        mkramfs: Path,
+        sysroot_path: Path,
+    ) -> bool:
+        """Run a single Windows test binary. Return True on success."""
+        name = binary.stem
+        log.info(f"RUN  {name}...")
+        with tempfile.TemporaryDirectory(
+            prefix=f"nanvix_{name}_", ignore_cleanup_errors=True,
+        ) as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            ramfs_dir = tmpdir_path / "ramfs"
+            ramfs_dir.mkdir()
+            (ramfs_dir / "tmp").mkdir(exist_ok=True)
+            shutil.copy2(binary, ramfs_dir / binary.name)
+
+            shared_sql = (
+                self.repo_root / ".nanvix" / "functional_test.sql"
+            )
+            sql_file = ramfs_dir / "_sqlite_test.sql"
+            shutil.copy2(shared_sql, sql_file)
+
+            ramfs_img = tmpdir_path / f"rootfs_{name}.img"
+            if not self._build_ramfs(mkramfs, ramfs_img, ramfs_dir, name):
+                return False
+            return self._execute_test(
+                nanvixd, sysroot_path, ramfs_img, binary, sql_file, name,
             )
 
-        failed = []
-        for binary in test_binaries:
-            name = binary.stem
-            print(f"RUN  {name}...")
-            with tempfile.TemporaryDirectory(prefix=f"nanvix_{name}_",
-                                             ignore_cleanup_errors=True) as tmpdir:
-                tmpdir_path = Path(tmpdir)
-                ramfs_dir = tmpdir_path / "ramfs"
-                ramfs_dir.mkdir()
-                (ramfs_dir / "tmp").mkdir(exist_ok=True)
-                shutil.copy2(binary, ramfs_dir / binary.name)
+    def _build_ramfs(
+        self, mkramfs: Path, ramfs_img: Path, ramfs_dir: Path, name: str,
+    ) -> bool:
+        """Build the ramfs image. Return True on success."""
+        try:
+            subprocess.run(  # noqa: S603
+                [
+                    str(mkramfs.resolve()),
+                    "-o", str(ramfs_img),
+                    str(ramfs_dir),
+                ],
+                check=True,
+                timeout=60,
+            )
+        except subprocess.CalledProcessError as e:
+            log.error(
+                f"FAIL {name} (mkramfs exit code {e.returncode})",
+            )
+            return False
+        except subprocess.TimeoutExpired:
+            log.error(f"FAIL {name} (mkramfs timeout)")
+            return False
+        return True
 
-                # Copy the shared SQL test script (single source of truth
-                # used by both Makefile.nanvix and this Windows test path).
-                shared_sql = self.repo_root / ".nanvix" / "functional_test.sql"
-                sql_file = ramfs_dir / "_sqlite_test.sql"
-                shutil.copy2(shared_sql, sql_file)
+    def _execute_test(  # noqa: PLR0913
+        self,
+        nanvixd: Path,
+        sysroot_path: Path,
+        ramfs_img: Path,
+        binary: Path,
+        sql_file: Path,
+        name: str,
+    ) -> bool:
+        """Execute a test binary via nanvixd. Return True on success."""
+        try:
+            sql_input = sql_file.read_bytes()
+            bin_dir = str((sysroot_path / "bin").resolve())
+            result = subprocess.run(  # noqa: S603
+                [
+                    str(nanvixd.resolve()),
+                    "-bin-dir", bin_dir,
+                    "-ramfs", str(ramfs_img),
+                    "--", str(binary.resolve()),
+                ],
+                input=sql_input,
+                timeout=120,
+                check=False,
+            )
+            if result.returncode != 0:
+                log.error(
+                    f"FAIL {name} (exit code {result.returncode})",
+                )
+                return False
+            log.info(f"OK   {name}")
+        except subprocess.TimeoutExpired:
+            log.error(f"FAIL {name} (timeout)")
+            return False
+        return True
 
-                # Write ramfs image alongside the ramfs source dir to avoid
-                # self-inclusion while keeping artifacts scoped to this temp dir.
-                ramfs_img = tmpdir_path / f"rootfs_{name}.img"
-                try:
-                    subprocess.run(
-                        [str(mkramfs.resolve()), "-o", str(ramfs_img), str(ramfs_dir)],
-                        check=True, timeout=60,
-                    )
-                except subprocess.CalledProcessError as e:
-                    print(f"FAIL {name} (mkramfs exit code {e.returncode})")
-                    failed.append(name)
-                    continue
-                except subprocess.TimeoutExpired:
-                    print(f"FAIL {name} (mkramfs timeout)")
-                    failed.append(name)
-                    continue
-                try:
-                    sql_input = sql_file.read_bytes()
-                    result = subprocess.run(
-                        [str(nanvixd.resolve()), "-bin-dir", str((sysroot_path / "bin").resolve()),
-                         "-ramfs", str(ramfs_img), "--", str(binary.resolve())],
-                        input=sql_input, timeout=120,
-                    )
-                    if result.returncode != 0:
-                        print(f"FAIL {name} (exit code {result.returncode})")
-                        failed.append(name)
-                    else:
-                        print(f"OK   {name}")
-                except subprocess.TimeoutExpired:
-                    print(f"FAIL {name} (timeout)")
-                    failed.append(name)
+    def _run_tests_windows(self) -> None:
+        """Run tests natively on Windows using nanvixd.exe.
+
+        Only standalone mode is tested on Windows; multi-process and
+        single-process require linuxd, which is Linux-only.
+        """
+        if self.config.deployment_mode != "standalone":
+            log.info(
+                f"Skipping tests on Windows for mode"
+                f" '{self.config.deployment_mode}' (requires linuxd).",
+            )
+            return
+
+        sysroot_path, nanvixd, mkramfs = self._resolve_windows_tools()
+        test_binaries = self._find_test_binaries()
+
+        failed = [
+            binary.stem
+            for binary in test_binaries
+            if not self._run_single_test(
+                binary, nanvixd, mkramfs, sysroot_path,
+            )
+        ]
 
         if failed:
-            msg = " ".join(failed)
-            raise RuntimeError(f"{len(failed)} test(s) failed: {msg}")
-        print(f"\t\t*** All {len(test_binaries)} tests PASSED ***")
+            msg = f"{len(failed)} test(s) failed: {' '.join(failed)}"
+            raise RuntimeError(msg)
+        log.info(
+            f"\t\t*** All {len(test_binaries)} tests PASSED ***",
+        )
 
     def release(self) -> None:
         """Package the SQLite release tarball and verify it."""
         self.run(*self._make_args("package"), cwd=self.repo_root)
-        self.run(*self._make_args("verify-package"), cwd=self.repo_root)
+        self.run(
+            *self._make_args("verify-package"), cwd=self.repo_root,
+        )
 
     def clean(self) -> None:
         """Remove build artifacts."""


### PR DESCRIPTION
## Summary

Resolves all Python lint issues in `.nanvix/z.py` reported by ruff (with all rules enabled) and Pyright.

## Changes

- **Import sorting** (I001): Reorganized imports per isort conventions
- **Ternary simplification** (FURB110): Replaced `x if x else y` with `x or y`
- **Line length** (E501): Wrapped long lines to stay within 88 chars
- **Print statements** (T201): Replaced `print()` with `log.info()`/`log.error()`
- **Exception messages** (EM102/TRY003): Assigned f-string to variable before raising
- **Complexity reduction** (C901/PLR0912/PLR0915): Refactored `_run_tests_windows` into smaller helper methods (`_resolve_windows_tools`, `_find_test_binaries`, `_run_single_test`, `_build_ramfs`, `_execute_test`)
- **subprocess.run check** (PLW1510): Added explicit `check=False`
- **Security suppressions** (S603): Added `noqa` for build-script subprocess calls
- **Type checking**: Added `type: ignore[import-not-found]` for external `nanvix_zutil`
- **Namespace package** (INP001): Added `__init__.py`
- **Trailing commas** (COM812): Added trailing commas to multi-line constructs