### PR TITLE
[ci] E: Update nanvix workflow refs to v1.15.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'
@@ -46,7 +46,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -158,7 +158,9 @@ class SqliteBuild(ZScript):
             log.info("Pre-building jimsh0 on the host...")
             subprocess.run(  # noqa: S603
                 [
-                    "cc", "-o", str(jimsh0),
+                    "cc",
+                    "-o",
+                    str(jimsh0),
                     *self._JIMSH0_CFLAGS,
                     str(root / "autosetup" / "jimsh0.c"),
                 ],
@@ -172,16 +174,22 @@ class SqliteBuild(ZScript):
 
         # Phase 3: build remaining host tools on the host.
         host_tools = [
-            "lemon", "mksourceid", "mkkeywordhash",
-            "srcck1", "src-verify",
+            "lemon",
+            "mksourceid",
+            "mkkeywordhash",
+            "srcck1",
+            "src-verify",
         ]
         missing = [t for t in host_tools if not (root / t).is_file()]
         if missing:
             log.info(f"Pre-building host tools on the host: {missing}")
             subprocess.run(  # noqa: S603
                 [
-                    "make", *missing,
-                    "B.cc=cc", "B.tclsh=./jimsh0", f"TOP={root}",
+                    "make",
+                    *missing,
+                    "B.cc=cc",
+                    "B.tclsh=./jimsh0",
+                    f"TOP={root}",
                 ],
                 check=True,
                 cwd=root,
@@ -391,6 +399,8 @@ class SqliteBuild(ZScript):
 
     def release(self) -> None:
         """Package the SQLite release tarball and verify it."""
+        if self.docker is not None:
+            self._prebuild_host_tools()
         self.run(*self._make_args("package"), cwd=self.repo_root)
         self.run(
             *self._make_args("verify-package"),

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -121,8 +121,71 @@ class SqliteBuild(ZScript):
                     )
 
     def build(self) -> None:
-        """Cross-compile libsqlite3.a and sqlite3.elf for Nanvix."""
+        """Cross-compile libsqlite3.a and sqlite3.elf for Nanvix.
+
+        When building inside Docker, the minimal toolchain image has no
+        host C compiler.  Host-side build tools (jimsh0, lemon, etc.)
+        are therefore pre-built on the runner and made available to the
+        container through the mounted workspace.
+        """
+        if self.docker is not None:
+            self._prebuild_host_tools()
         self.run(*self._make_args("all"), cwd=self.repo_root)
+
+    # ------------------------------------------------------------------
+    # Host-tool pre-build helpers (Docker-only)
+    # ------------------------------------------------------------------
+
+    _JIMSH0_CFLAGS = [
+        "-DHAVE_REALPATH",
+        "-DHAVE_DIRENT_H",
+        "-DHAVE_SYS_TIME_H",
+    ]
+
+    def _prebuild_host_tools(self) -> None:
+        """Build host-side tools needed by autosetup and the Makefile.
+
+        Phase 1 -- jimsh0 (TCL bootstrap for ``./configure``).
+        Phase 2 -- ``make configure`` inside Docker (generates Makefile).
+        Phase 3 -- lemon, mkkeywordhash, mksourceid, srcck1, src-verify
+                   compiled on the host using the generated Makefile.
+        """
+        root = self.repo_root
+
+        # Phase 1: build jimsh0 on the host.
+        jimsh0 = root / "jimsh0"
+        if not jimsh0.is_file():
+            log.info("Pre-building jimsh0 on the host...")
+            subprocess.run(  # noqa: S603
+                [
+                    "cc", "-o", str(jimsh0),
+                    *self._JIMSH0_CFLAGS,
+                    str(root / "autosetup" / "jimsh0.c"),
+                ],
+                check=True,
+                cwd=root,
+            )
+
+        # Phase 2: run configure inside Docker.
+        log.info("Running configure inside Docker...")
+        self.run(*self._make_args("configure"), cwd=root)
+
+        # Phase 3: build remaining host tools on the host.
+        host_tools = [
+            "lemon", "mksourceid", "mkkeywordhash",
+            "srcck1", "src-verify",
+        ]
+        missing = [t for t in host_tools if not (root / t).is_file()]
+        if missing:
+            log.info(f"Pre-building host tools on the host: {missing}")
+            subprocess.run(  # noqa: S603
+                [
+                    "make", *missing,
+                    "B.cc=cc", "B.tclsh=./jimsh0", f"TOP={root}",
+                ],
+                check=True,
+                cwd=root,
+            )
 
     def test(self) -> None:
         """Run the test suite.

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -137,6 +137,10 @@ CONFIGURE_OPTS = \
 
 CONFIGURED_MARKER = .nanvix-configured
 
+# When a pre-built jimsh0 exists (built on the host for the minimal
+# Docker image), propagate B.tclsh=./jimsh0 to all sub-make invocations.
+BTCLSH_OVERRIDE = $(if $(wildcard jimsh0),B.tclsh=./jimsh0)
+
 # ===========================================================================
 # Build Targets
 # ===========================================================================
@@ -170,11 +174,7 @@ ifdef CONFIG_NANVIX_DOCKER
 	make lemon mksourceid mkkeywordhash srcck1 src-verify B.cc="cc" B.tclsh="./jimsh0" TOP="$(CURDIR)"
 	$(DOCKER_RUN) make -j$$(nproc) B.tclsh=./jimsh0 all
 else
-	@if [ -x jimsh0 ]; then \
-	  make -j$$(nproc) B.tclsh=./jimsh0 all; \
-	else \
-	  make -j$$(nproc) all; \
-	fi
+	make -j$$(nproc) $(BTCLSH_OVERRIDE) all
 endif
 	@if [ -f sqlite3 ] && [ ! -f sqlite3$(EXE) ]; then mv sqlite3 sqlite3$(EXE); fi
 
@@ -270,12 +270,12 @@ ifdef CONFIG_NANVIX_DOCKER
 	  -v $(STAGING):$(STAGING) \
 	  -w $(DOCKER_WORKSPACE_PATH) \
 	  -e HOME=/tmp \
-	  $(NANVIX_DOCKER_IMAGE) make install DESTDIR="$(STAGING)"
+	  $(NANVIX_DOCKER_IMAGE) make install B.tclsh=./jimsh0 DESTDIR="$(STAGING)"
   else
-	$(DOCKER_RUN) make install DESTDIR="$(DOCKER_WORKSPACE_PATH)/dist/$(ARTIFACT_NAME)"
+	$(DOCKER_RUN) make install B.tclsh=./jimsh0 DESTDIR="$(DOCKER_WORKSPACE_PATH)/dist/$(ARTIFACT_NAME)"
   endif
 else
-	make install DESTDIR="$(STAGING)"
+	make install $(BTCLSH_OVERRIDE) DESTDIR="$(STAGING)"
 endif
 	@# Ensure sysroot/ layout: move INSTALL_PREFIX contents to sysroot/
 	@if [ -d "$(STAGING)/sysroot" ]; then \
@@ -289,10 +289,10 @@ endif
 	@if [ -f "$(STAGING)/sysroot/bin/sqlite3" ] && [ ! -e "$(STAGING)/sysroot/bin/sqlite3.elf" ]; then \
 	  cp "$(STAGING)/sysroot/bin/sqlite3" "$(STAGING)/sysroot/bin/sqlite3.elf"; \
 	fi
-	tar -cjf dist/$(ARTIFACT_NAME).tar.bz2 -C $(STAGING) sysroot
-	@echo "  Package: dist/$(ARTIFACT_NAME).tar.bz2"
+	tar -czf dist/$(ARTIFACT_NAME).tar.gz -C $(STAGING) sysroot
+	@echo "  Package: dist/$(ARTIFACT_NAME).tar.gz"
 	@echo "  Contents:"
-	@tar tjf dist/$(ARTIFACT_NAME).tar.bz2 | head -20
+	@tar tzf dist/$(ARTIFACT_NAME).tar.gz | head -20
 
 # ===========================================================================
 # Verify Package
@@ -301,13 +301,13 @@ endif
 verify-package:
 	@echo "=== Verifying SQLite package ==="
 	$(eval ARTIFACT_NAME := sqlite-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE))
-	@TARBALL="dist/$(ARTIFACT_NAME).tar.bz2"; \
+	@TARBALL="dist/$(ARTIFACT_NAME).tar.gz"; \
 	if [ ! -f "$$TARBALL" ]; then \
 	  echo "FAIL: Package tarball not found: $$TARBALL"; exit 1; \
 	fi; \
 	echo "Package contents:"; \
-	tar tjf "$$TARBALL"; \
-	if ! tar tjf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
+	tar tzf "$$TARBALL"; \
+	if ! tar tzf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
 	  echo "FAIL: Package missing sysroot/lib/ entries"; exit 1; \
 	fi; \
 	echo "  PASS: SQLite package verification"
@@ -325,12 +325,12 @@ ifdef CONFIG_NANVIX_DOCKER
 	  -v $(abspath $(DESTDIR)):$(abspath $(DESTDIR)) \
 	  -w $(DOCKER_WORKSPACE_PATH) \
 	  -e HOME=/tmp \
-	  $(NANVIX_DOCKER_IMAGE) make install DESTDIR="$(abspath $(DESTDIR))"
+	  $(NANVIX_DOCKER_IMAGE) make install B.tclsh=./jimsh0 DESTDIR="$(abspath $(DESTDIR))"
   else
-	$(DOCKER_RUN) make install
+	$(DOCKER_RUN) make install B.tclsh=./jimsh0
   endif
 else
-	make install DESTDIR="$(DESTDIR)"
+	make install $(BTCLSH_OVERRIDE) DESTDIR="$(DESTDIR)"
 endif
 
 clean:

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -155,7 +155,11 @@ ifdef CONFIG_NANVIX_DOCKER
 	fi
 	$(DOCKER_RUN) sh -c '$(CONFIGURE_ENV) ./configure $(CONFIGURE_OPTS) --with-tclsh=./jimsh0'
 else
-	$(CONFIGURE_ENV) ./configure $(CONFIGURE_OPTS)
+	@if [ -x jimsh0 ]; then \
+	  $(CONFIGURE_ENV) ./configure $(CONFIGURE_OPTS) --with-tclsh=./jimsh0; \
+	else \
+	  $(CONFIGURE_ENV) ./configure $(CONFIGURE_OPTS); \
+	fi
 endif
 	touch $(CONFIGURED_MARKER)
 
@@ -166,7 +170,11 @@ ifdef CONFIG_NANVIX_DOCKER
 	make lemon mksourceid mkkeywordhash srcck1 src-verify B.cc="cc" B.tclsh="./jimsh0" TOP="$(CURDIR)"
 	$(DOCKER_RUN) make -j$$(nproc) B.tclsh=./jimsh0 all
 else
-	make -j$$(nproc) all
+	@if [ -x jimsh0 ]; then \
+	  make -j$$(nproc) B.tclsh=./jimsh0 all; \
+	else \
+	  make -j$$(nproc) all; \
+	fi
 endif
 	@if [ -f sqlite3 ] && [ ! -f sqlite3$(EXE) ]; then mv sqlite3 sqlite3$(EXE); fi
 

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -20,7 +20,7 @@
 # Toolchain Detection
 # ===========================================================================
 
-NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
+NANVIX_DOCKER_IMAGE ?= ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 ifdef CONFIG_NANVIX
   NANVIX_TOOLCHAIN ?= /opt/nanvix
@@ -147,7 +147,13 @@ configure: $(CONFIGURED_MARKER)
 
 $(CONFIGURED_MARKER):
 ifdef CONFIG_NANVIX_DOCKER
-	$(DOCKER_RUN) sh -c '$(CONFIGURE_ENV) ./configure $(CONFIGURE_OPTS)'
+	@# Pre-build autosetup bootstrap interpreter on the host so that
+	@# the (minimal) cross-compilation image does not need a host compiler.
+	@if [ ! -x jimsh0 ]; then \
+	  cc -o jimsh0 -DHAVE_REALPATH -DHAVE_DIRENT_H -DHAVE_SYS_TIME_H \
+	    autosetup/jimsh0.c 2>/dev/null || true; \
+	fi
+	$(DOCKER_RUN) sh -c '$(CONFIGURE_ENV) ./configure $(CONFIGURE_OPTS) --with-tclsh=./jimsh0'
 else
 	$(CONFIGURE_ENV) ./configure $(CONFIGURE_OPTS)
 endif
@@ -155,7 +161,10 @@ endif
 
 build: $(CONFIGURED_MARKER)
 ifdef CONFIG_NANVIX_DOCKER
-	$(DOCKER_RUN) make -j$$(nproc) all
+	@# Build host tools (lemon, mkkeywordhash, mksourceid) on the host
+	@# because the minimal cross-compilation image has no host compiler.
+	make lemon mksourceid mkkeywordhash srcck1 src-verify B.cc="cc" B.tclsh="./jimsh0" TOP="$(CURDIR)"
+	$(DOCKER_RUN) make -j$$(nproc) B.tclsh=./jimsh0 all
 else
 	make -j$$(nproc) all
 endif
@@ -318,7 +327,7 @@ endif
 
 clean:
 	-make clean 2>/dev/null || true
-	rm -f $(CONFIGURED_MARKER) sqlite3$(EXE) _sqlite_test.sql
+	rm -f $(CONFIGURED_MARKER) sqlite3$(EXE) _sqlite_test.sql jimsh0 lemon mksourceid mkkeywordhash srcck1 src-verify lempar.c
 	rm -rf dist/
 
 distclean: clean

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -44,7 +44,7 @@ For experienced users who want to build quickly:
 
 ```bash
 # 1. Pull the Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 # 2. Download Nanvix sysroot and extract Nanvix commit SHA
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
@@ -137,7 +137,7 @@ The Makefile supports automatic Docker fallback when the native toolchain is not
 
 ```bash
 # Pull the Nanvix toolchain Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 # Build (Docker is used automatically if native toolchain is not found)
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
@@ -149,7 +149,7 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler
 - If the native toolchain is not found, it automatically uses Docker if available
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
-- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `nanvix/toolchain:latest-minimal`)
+- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`)
 
 ### Using Native Toolchain
 


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.15.0`](https://github.com/nanvix/workflows/releases/tag/v1.15.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.