### PR TITLE
fix: suppress pyright errors for inherited docker attribute

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -128,7 +128,10 @@ class SqliteBuild(ZScript):
         are therefore pre-built on the runner and made available to the
         container through the mounted workspace.
         """
-        if self.docker is not None:
+        if (
+            self.docker  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+            is not None
+        ):
             self._prebuild_host_tools()
         self.run(*self._make_args("all"), cwd=self.repo_root)
 
@@ -399,7 +402,10 @@ class SqliteBuild(ZScript):
 
     def release(self) -> None:
         """Package the SQLite release tarball and verify it."""
-        if self.docker is not None:
+        if (
+            self.docker  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+            is not None
+        ):
             self._prebuild_host_tools()
         self.run(*self._make_args("package"), cwd=self.repo_root)
         self.run(


### PR DESCRIPTION
## Problem

The latest merge (PR #184) introduced `self.docker` references in `.nanvix/z.py` that cause pyright to fail in strict mode during the **Format & Lint** CI job.

Pyright cannot resolve the `docker` attribute inherited from `ZScript` (nanvix_zutil) because `DockerConfig` and several other nanvix_zutil types appear as `Unknown` to the type checker — even though the package ships `py.typed` and the venv is correctly configured.

## Root cause

In pyright strict mode, attributes whose type annotations reference nanvix_zutil submodule types (`DockerConfig`, `Manifest`, `Sysroot`, `Buildroot`) are not fully resolved. Attributes with stdlib types (`Path`, `list[str]`) work fine. This is a known limitation when pyright analyzes consumer code that inherits from a library class with complex internal type dependencies.

## Fix

Add `# pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]` comments on the two lines accessing `self.docker`, matching the suppress pattern already used in the nanvix_zutil codebase itself (`docker.py`). The comments are placed on the `self.docker` expression line to satisfy both pyright and black formatting.

## Verification

- `pyright --project .nanvix/pyrightconfig.json`: **0 errors**
- `black --check .nanvix/z.py`: **unchanged**