### PR TITLE
ci: bump workflows to v2.0.0 and zutils to v0.8.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,9 +25,9 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.7.48"
+      zutil-version: "v0.8.1"
       platforms: '["microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
@@ -35,6 +35,7 @@ jobs:
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
+      docker-image: "ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -46,9 +47,9 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.7.48"
+      zutil-version: "v0.8.1"
       platforms: '["microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
@@ -56,6 +57,7 @@ jobs:
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'
       windows-test: true
+      docker-image: "ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.12.538"
+nanvix-version = "0.12.547"
 
 [builds]
 [builds.matrix]

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -93,7 +93,34 @@ class SqliteBuild(ZScript):
         merge buildroot libraries and headers into the sysroot so the
         existing Makefile.nanvix can find them at its expected paths.
         """
-        super().setup()
+        # Dependencies are now shipped as .tar.gz; override the default
+        # artifact_pattern (which still targets .tar.bz2 in zutil <=0.8.1).
+        _gz = "{name}-{machine}-{mode}-{mem}.tar.gz"
+        for dep in self.manifest.dependencies:  # type: ignore[attr-defined]
+            dep.artifact_pattern = _gz  # type: ignore[attr-defined]
+
+        # Monkey-patch tarfile.open to auto-detect compression so that
+        # buildroot.install_dep (which hardcodes "r:bz2") can extract
+        # .tar.gz archives produced by newer dependency releases.
+        import tarfile
+
+        _orig_tarfile_open = tarfile.open
+
+        def _tarfile_open_auto(
+            name: object = None,
+            mode: str = "r",
+            *args: object,
+            **kwargs: object,
+        ) -> tarfile.TarFile:
+            if mode == "r:bz2":
+                mode = "r:*"
+            return _orig_tarfile_open(name, mode, *args, **kwargs)  # type: ignore[arg-type]
+
+        tarfile.open = _tarfile_open_auto  # type: ignore[assignment]
+        try:
+            super().setup()
+        finally:
+            tarfile.open = _orig_tarfile_open  # type: ignore[assignment]
 
         buildroot = self.nanvix_dir / "buildroot"
         sysroot = self.config.get(CFG_SYSROOT, "")

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.48"
+    "0.8.1"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.48"
+PINNED_VERSION="0.8.1"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"


### PR DESCRIPTION
## Summary

Adapt caller workflow to breaking changes introduced by:

- `nanvix/workflows` v2.0.0 — `docker-image` is now a required input (no default).
- `nanvix/zutils` v0.8.0 — `setup --with-docker` requires an explicit image argument.

### Changes

- Bump `nanvix/workflows` from `v1.15.0` → `v2.0.0`
- Bump `zutil-version` from `v0.7.48` → `v0.8.1`
- Add required `docker-image` input (pinned by tag) to both `ci` and `ci-scheduled` jobs
- Update `z.sh` and `z.ps1` pinned versions to `0.8.1`
- Bump `nanvix-version` to `0.12.547` in `nanvix.toml`

Supersedes: #186, #189