### PR TITLE
refactor: remove archive format monkey-patches (zutils 0.8.2)

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -93,34 +93,7 @@ class SqliteBuild(ZScript):
         merge buildroot libraries and headers into the sysroot so the
         existing Makefile.nanvix can find them at its expected paths.
         """
-        # Dependencies are now shipped as .tar.gz; override the default
-        # artifact_pattern (which still targets .tar.bz2 in zutil <=0.8.1).
-        _gz = "{name}-{machine}-{mode}-{mem}.tar.gz"
-        for dep in self.manifest.dependencies:  # type: ignore[attr-defined]
-            dep.artifact_pattern = _gz  # type: ignore[attr-defined]
-
-        # Monkey-patch tarfile.open to auto-detect compression so that
-        # buildroot.install_dep (which hardcodes "r:bz2") can extract
-        # .tar.gz archives produced by newer dependency releases.
-        import tarfile
-
-        _orig_tarfile_open = tarfile.open
-
-        def _tarfile_open_auto(
-            name: object = None,
-            mode: str = "r",
-            *args: object,
-            **kwargs: object,
-        ) -> tarfile.TarFile:
-            if mode == "r:bz2":
-                mode = "r:*"
-            return _orig_tarfile_open(name, mode, *args, **kwargs)  # type: ignore[arg-type]
-
-        tarfile.open = _tarfile_open_auto  # type: ignore[assignment]
-        try:
-            super().setup()
-        finally:
-            tarfile.open = _orig_tarfile_open  # type: ignore[assignment]
+        super().setup()
 
         buildroot = self.nanvix_dir / "buildroot"
         sysroot = self.config.get(CFG_SYSROOT, "")


### PR DESCRIPTION
zutils v0.8.2 natively handles `.tar.gz`, `.tar.bz2` and `.zip` archives via `tarfile.open("r:*")` and `zipfile.is_zipfile()`.

Remove the `setup()` overrides that monkey-patched `tarfile.open` to work around the old hardcoded `r:bz2` extraction mode.