### PR TITLE
[ci] E: Pin nanvix to v0.13.11

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.13.3"
+nanvix-version = "0.13.11"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.13.11`](https://github.com/nanvix/nanvix/releases/tag/v0.13.11).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.