### PR TITLE
[ci] Sync zutils v0.8.5

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
-      zutil-version: "v0.8.4"
+      zutil-version: "v0.8.5"
       platforms: '["microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
-      zutil-version: "v0.8.4"
+      zutil-version: "v0.8.5"
       platforms: '["microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.13.15"
+nanvix-version = "0.13.16"
 
 [builds]
 [builds.matrix]

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.8.4"
+    "0.8.5"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.8.4"
+PINNED_VERSION="0.8.5"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"


### PR DESCRIPTION
Automated sync with [`v0.8.5`](https://github.com/nanvix/zutils/releases/tag/v0.8.5):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.13.16` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.