### PR TITLE
[ci] Sync zutils v0.10.1

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.15.13"
+nanvix-version = "0.15.19"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated sync with [`v0.10.1`](https://github.com/nanvix/zutils/releases/tag/v0.10.1):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.15.19` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.