### PR TITLE
[ci] E: Pin nanvix to v0.16.32

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.16.17"
+nanvix-version = "0.16.32"
 
 [builds]
 [builds.matrix]

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -78,6 +78,11 @@ LIBC := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a
 LIBM := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a
 LIBPOSIX := $(SYSROOT_PATH)/lib/libposix.a
 LIBZ := $(SYSROOT_PATH)/lib/libz.a
+# Since Nanvix 0.16.19, process startup (_start) lives in libnvx_crt0.a; it
+# must be linked first so its strong _start overrides the toolchain's weak
+# no-op stub (otherwise the guest never reaches main and hangs). The wildcard
+# keeps this empty on older releases that do not ship the archive.
+LIBNVX_CRT0 := $(wildcard $(SYSROOT_PATH)/lib/libnvx_crt0.a)
 
 CONFIGURE_ENV = \
 AR="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-ar" \
@@ -87,8 +92,8 @@ CXX="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-g++" \
 CPP="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-cpp" \
 LD="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-ld" \
 CFLAGS="-I$(SYSROOT_PREFIX)/include -DSQLITE_OMIT_WAL=1" \
-LDFLAGS="-static -T$(SYSROOT_PREFIX)/lib/user.ld -L$(SYSROOT_PREFIX)/lib -Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBM) $(LIBZ) -Wl,--end-group" \
-LIBS="-Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBM) $(LIBZ) -Wl,--end-group"
+LDFLAGS="-static -T$(SYSROOT_PREFIX)/lib/user.ld -L$(SYSROOT_PREFIX)/lib -Wl,--allow-multiple-definition -Wl,--start-group $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) $(LIBM) $(LIBZ) -Wl,--end-group" \
+LIBS="-Wl,--start-group $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) $(LIBM) $(LIBZ) -Wl,--end-group"
 
 CONFIGURE_OPTS = \
 --disable-shared \


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.16.32`](https://github.com/nanvix/nanvix/releases/tag/v0.16.32).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.