### PR TITLE
[nanvix] Name release assets per build configuration

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -27,6 +27,8 @@ from nanvix_zutil import (
     log,
     make_initrd,
     run,
+    load_manifest,
+    package,
 )
 from nanvix_zutil.paths import (
     bin_out,
@@ -37,6 +39,7 @@ from nanvix_zutil.paths import (
     nanvix_root,
     out_dir,
     repo_root,
+    release_dir,
 )
 
 IS_WINDOWS = sys.platform == "win32"
@@ -526,6 +529,27 @@ class SqliteBuild(ZScript):
         log.info(
             f"\t\t*** All {len(test_binaries)} tests PASSED ***",
         )
+
+    def release(self) -> None:
+        """Package the release archive named per build configuration.
+
+        The base :meth:`ZScript.release` packages ``release_dir()`` under the
+        bare package name, so every matrix configuration emits an
+        identically-named archive; in CI these collide and overwrite one
+        another, leaving the published release with only generic assets.
+        Dependents resolve assets by the pattern
+        ``{name}-{machine}-{mode}-{mem}`` (e.g.
+        ``{name}-microvm-multi-process-128mb``), so the archive must carry that
+        name for dependency installation to succeed.
+        """
+        manifest = load_manifest()
+        name = (
+            f"{manifest.name}"
+            f"-{self.config.machine}"
+            f"-{self.config.deployment_mode}"
+            f"-{self.config.memory_size}"
+        )
+        package([release_dir()], dist_dir(), name)
 
     def clean(self) -> None:
         """Remove build artifacts."""


### PR DESCRIPTION
## Problem

Dependent repos fail their Nanvix CI **Setup** step with:

```
error: Asset '<name>-microvm-multi-process-128mb' not found in release <repo>@<ver>-nanvix-<nver>
```

Recent releases publish only generic `<name>.tar.gz` / `<name>.zip` assets instead of the per-configuration assets (`<name>-microvm-multi-process-128mb.tar.gz`, ...) that dependents resolve.

## Root cause

During the zutils **v0.11** migration the per-config `release()` override in `.nanvix/z.py` was removed, so execution falls through to the base `ZScript.release()`:

```python
package([release_dir()], dist_dir(), manifest.name)  # name = "<name>"
```

This names the archive after the bare package name, so **every** matrix configuration emits an identically-named `<name>.tar.gz`/`<name>.zip`. In the reusable release job all matrix artifacts are copied into one directory (`cp {} release-assets/`), so they collide and overwrite each other — leaving the published release with only generic assets.

Consumers still resolve dependency assets via zutils' `artifact_pattern = "{name}-{machine}-{mode}-{mem}"` (`buildroot.py`), which no longer exists → dependency install fails.

## Fix

Override `release()` to package the release tree under `{name}-{machine}-{mode}-{mem}`, matching what dependents resolve. Each matrix config now emits a uniquely-named archive, so they no longer collide and all per-config assets are published.

This mirrors the fix applied to `nanvix/zlib`.

## Verification

- `python -m py_compile .nanvix/z.py` passes.
- `black --check` (line-length 88) passes.
- `pyright` (strict) passes with 0 errors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
