### PR TITLE
[build] E: Build libsqlite3.so alongside libsqlite3.a

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -189,6 +189,7 @@ class SqliteBuild(ZScript):
         root = repo_root()
         return [
             str((lib_out() / "libsqlite3.a").relative_to(root)),
+            str((lib_out() / "libsqlite3.so").relative_to(root)),
             str((include_out() / "sqlite3.h").relative_to(root)),
             str((include_out() / "sqlite3ext.h").relative_to(root)),
             str((bin_out() / "sqlite3.elf").relative_to(root)),

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -51,7 +51,7 @@ INSTALL_PREFIX ?= $(SYSROOT_PATH)
 
 # Artifacts staged by `install` into the release/test output tree so that
 # `./z release` (which packages release_dir()) can find them.
-LIB_ARTIFACTS     := libsqlite3.a
+LIB_ARTIFACTS     := libsqlite3.a libsqlite3.so
 INCLUDE_ARTIFACTS := sqlite3.h src/sqlite3ext.h
 BIN_ARTIFACTS     := sqlite3$(EXE)
 
@@ -93,7 +93,7 @@ CC="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-gcc" \
 CXX="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-g++" \
 CPP="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-cpp" \
 LD="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-ld" \
-CFLAGS="-I$(SYSROOT_PREFIX)/include -DSQLITE_OMIT_WAL=1" \
+CFLAGS="-I$(SYSROOT_PREFIX)/include -fPIC -DSQLITE_OMIT_WAL=1" \
 LDFLAGS="-static -T$(SYSROOT_PREFIX)/lib/user.ld -L$(SYSROOT_PREFIX)/lib -Wl,--allow-multiple-definition -Wl,--start-group $(LIBCRT0) $(LIBPOSIX) $(LIBC) $(LIBM) $(LIBZ) -Wl,--end-group" \
 LIBS="-Wl,--start-group $(LIBCRT0) $(LIBPOSIX) $(LIBC) $(LIBM) $(LIBZ) -Wl,--end-group"
 
@@ -129,6 +129,27 @@ $(CONFIGURED_MARKER):
 build: $(CONFIGURED_MARKER)
 	make -j$$(nproc) $(BTCLSH_OVERRIDE) all
 	@if [ -f sqlite3 ] && [ ! -f sqlite3$(EXE) ]; then mv sqlite3 sqlite3$(EXE); fi
+	@# Link libsqlite3.so from the (now PIC) static archive via
+	@# --whole-archive so every sqlite3 entry point becomes part of the
+	@# .so's .dynsym.  Set DT_SONAME so consumers that link `-lsqlite3`
+	@# against this .so emit a proper DT_NEEDED entry.  libc / libm /
+	@# libz symbols are left UND via -nostdlib and bind at dlopen time
+	@# against the host executable's .dynsym, matching the model used
+	@# by other Nanvix shared libraries such as libffi.so / libssl.so.
+	@#
+	@# `-static-libgcc -lgcc` embeds the small set of libgcc helpers
+	@# that sqlite3.c needs for 64-bit integer arithmetic on i686
+	@# (__divdi3 / __moddi3 / __udivdi3 / __umoddi3, all STV_HIDDEN
+	@# inside libgcc).  Without them, ld leaves the symbols UND in
+	@# libsqlite3.so and the cpython configure-time hello-world probe
+	@# (`-lsqlite3 -lpthread -ldl`, no libgcc) fails to link, which
+	@# silently drops `-lsqlite3` from `_sqlite3.cpython-312.so`'s
+	@# DT_NEEDED list and breaks dlopen at runtime.
+	$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-gcc -shared -fPIC -nostdlib \
+	    -Wl,-soname,libsqlite3.so -Wl,-z,noexecstack \
+	    -Wl,--whole-archive libsqlite3.a -Wl,--no-whole-archive \
+	    -static-libgcc -lgcc \
+	    -o libsqlite3.so
 
 # Stage built artifacts into the release/test output tree so that
 # `./z release` (which packages release_dir()) can find them.
@@ -169,6 +190,7 @@ test: test-functional
 clean:
 	-make clean 2>/dev/null || true
 	rm -f $(CONFIGURED_MARKER) sqlite3$(EXE) _sqlite_test.sql jimsh0 lemon mksourceid mkkeywordhash srcck1 src-verify lempar.c
+	rm -f libsqlite3.so
 	rm -rf $(OUT_DIR) dist/
 
 distclean: clean


### PR DESCRIPTION
## Summary

Builds `libsqlite3.so` alongside the existing `libsqlite3.a` so consumers can `dlopen` sqlite3 at run time instead of statically linking it.

## Why

Today the Nanvix sqlite port ships only `libsqlite3.a`. Anything that wants sqlite3 (e.g., cpython's `_sqlite3` extension) has to statically embed it into the consumer binary. That works for cpython's monolithic `python.elf` but does not allow:

- Sharing a single libsqlite3 implementation across multiple `.so` consumers in the same process.
- Building a cpython `_sqlite3.so` that resolves sqlite3 via `DT_NEEDED libsqlite3.so` (the model already used by `_ssl.so` → `libssl.so` and `_ctypes.so` → `libffi.so` on Nanvix).

Producing `libsqlite3.so` here unblocks the cpython migration of `_sqlite3` from `--whole-archive .a in python.elf` to `DT_NEEDED .so`.

## What changed

sqlite uses autotools and the upstream `--enable-shared` path goes through `libtool`, which does not know about `i686-nanvix`. Rather than teaching libtool a new platform target, this PR keeps `--disable-shared` and links `libsqlite3.so` manually from the `.a` inside the `build` recipe, the same approach already taken by [nanvix/libffi#235](https://github.com/nanvix/libffi/pull/235).

Concretely:

- `Makefile.nanvix`:
  - `CONFIGURE_ENV` `CFLAGS` gains `-fPIC` so the same `.o` files compile into both `.a` and `.so`.
  - `build` recipe extended with a `gcc -shared` invocation that links `libsqlite3.so` from `libsqlite3.a` via `-Wl,--whole-archive` with `DT_SONAME=libsqlite3.so` and `-nostdlib` (libc / libm / libz UND, bind at dlopen).
  - `LIB_ARTIFACTS` gains `libsqlite3.so`, so the existing `install` recipe copies it to `LIB_OUT` automatically.
- `.nanvix/z.py`:
  - `_staged_output_files` extended with `libsqlite3.so` so Windows tar-copy mode copies the install-staged `.so` back to the host workspace after the container exits.

## Architecture

```
libsqlite3.so       (PIC-recompiled from libsqlite3.a)
  └── UND libc / libm / libz symbols (memcpy, malloc, deflate, ...)
      → resolved against the host executable's .dynsym at dlopen time

libsqlite3.a (unchanged shape; same .o files now compiled with -fPIC)
```

`libsqlite3.so` has no transitive `.so` dependencies (sqlite3 is self-contained; libc/libm/libz symbols are UND), so the loader does not need to walk any DT_NEEDED chain to load it.

## Dependencies

**Runtime dep (already merged upstream):**

- [nanvix/nanvix#2473](https://github.com/nanvix/nanvix/pull/2473) — `dlfcn` init-array + DT_RUNPATH support. Required for any consumer to `dlopen("libsqlite3.so")` at run time.

## Validation

Build runs end-to-end inside the toolchain-gcc Docker image:

```
$ ./z build
... (compiles sqlite3 sources with -fPIC) ...
i686-nanvix-gcc -shared -fPIC -nostdlib \
    -Wl,-soname,libsqlite3.so -Wl,-z,noexecstack \
    -Wl,--whole-archive libsqlite3.a -Wl,--no-whole-archive \
    -o libsqlite3.so
install -m 644 libsqlite3.a libsqlite3.so     /mnt/workspace/.nanvix/out/release/lib/
success: Build complete
```

Structural verification of the produced `libsqlite3.so` (~996 KB):

```
$ i686-nanvix-readelf -d .nanvix/out/release/lib/libsqlite3.so | grep -E 'SONAME|NEEDED'
 0x0000000e (SONAME)                     Library soname: [libsqlite3.so]

$ i686-nanvix-nm -D .nanvix/out/release/lib/libsqlite3.so | grep ' T sqlite3_' | head -5
0003d2c9 T sqlite3_aggregate_context
0003d46e T sqlite3_aggregate_count
0007b993 T sqlite3_auto_extension
000ba62e T sqlite3_autovacuum_pages
00033058 T sqlite3_backup_finish
```

SONAME correctly set, no spurious DT_NEEDED, full `sqlite3_*` public API exported, libc symbols left UND for runtime binding. The existing `libsqlite3.a` and `sqlite3.elf` test binary continue to build unchanged.

