### PR TITLE
[ci] Sync zutils v0.11.1

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.16.103"
+nanvix-version = "0.16.115"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated sync with [`v0.11.1`](https://github.com/nanvix/zutils/releases/tag/v0.11.1):
- Pins `.zutils-version` to `v0.11.1` (source of truth on workflows@v2.1.0+).
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.16.115` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.