### PR TITLE
Rm release override

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -27,8 +27,6 @@ from nanvix_zutil import (
     log,
     make_initrd,
     run,
-    load_manifest,
-    package,
 )
 from nanvix_zutil.paths import (
     bin_out,
@@ -39,7 +37,6 @@ from nanvix_zutil.paths import (
     nanvix_root,
     out_dir,
     repo_root,
-    release_dir,
 )
 
 IS_WINDOWS = sys.platform == "win32"
@@ -529,27 +526,6 @@ class SqliteBuild(ZScript):
         log.info(
             f"\t\t*** All {len(test_binaries)} tests PASSED ***",
         )
-
-    def release(self) -> None:
-        """Package the release archive named per build configuration.
-
-        The base :meth:`ZScript.release` packages ``release_dir()`` under the
-        bare package name, so every matrix configuration emits an
-        identically-named archive; in CI these collide and overwrite one
-        another, leaving the published release with only generic assets.
-        Dependents resolve assets by the pattern
-        ``{name}-{machine}-{mode}-{mem}`` (e.g.
-        ``{name}-microvm-multi-process-128mb``), so the archive must carry that
-        name for dependency installation to succeed.
-        """
-        manifest = load_manifest()
-        name = (
-            f"{manifest.name}"
-            f"-{self.config.machine}"
-            f"-{self.config.deployment_mode}"
-            f"-{self.config.memory_size}"
-        )
-        package([release_dir()], dist_dir(), name)
 
     def clean(self) -> None:
         """Remove build artifacts."""


### PR DESCRIPTION
Removes the redundant release override; the base `ZScript.release()` in nanvix-zutil v0.12.0 already implements the same suffix-naming pattern (`{name}-{machine}-{deployment_mode}-{memory_size}`).

Verified the full lifecycle on Linux and Windows before and after the change: release archive filenames and contents match.

Towards nanvix/zutils#191.