### PR TITLE
[ci] Sync zutils v0.13.0

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.17.28"
+nanvix-version = "0.17.45"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated sync with [`v0.13.0`](https://github.com/nanvix/zutils/releases/tag/v0.13.0):
- Pins `.zutils-version` to `v0.13.0` (source of truth on workflows@v2.1.0+).
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.17.45` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.