### PR TITLE
fix: revert nanvix v0.19.9 pin to restore green CI

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite"
 version = "3.49.0"
-nanvix-version = "0.19.9"
+nanvix-version = "0.17.84"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
CI on the default branch has been failing since the automated `Pin nanvix to v0.19.9` merge landed. Reverts that merge to restore green CI. The last-known-good commit was the parent of the revert.