### PR TITLE
[sdk] E: Remove duplicate image pin

### DIFF
--- a/.nanvix/NANVIX.md
+++ b/.nanvix/NANVIX.md
@@ -43,11 +43,10 @@ This document describes the port of [SQLite](https://sqlite.org/) database engin
 For experienced users who want to build quickly:
 
 ```bash
-SDK=ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
 NANVIX_MACHINE=microvm \
 NANVIX_DEPLOYMENT_MODE=standalone \
 NANVIX_MEMORY_SIZE=256mb \
-  ./z setup --with-docker "$SDK"
+  ./z setup
 ./z build
 ./z test
 ```
@@ -62,7 +61,7 @@ You need the following components to build SQLite for Nanvix:
 
 | Component | Description | Default Location |
 |-----------|-------------|------------------|
-| **Nanvix SDK** | Clang/LLVM C SDK v0.20.0-sdk.1 | Docker image |
+| **Nanvix SDK** | Canonical Clang/LLVM C SDK | `.nanvix/nanvix.toml` |
 | **Nanvix runtime** | Nanvix 0.20.0 binaries used by tests | `.nanvix/sysroot` |
 | **zlib** | SDK-built release 1.3.1-nanvix-0.20.0 | `.nanvix/buildroot` |
 
@@ -89,8 +88,7 @@ the SDK; the downloaded runtime sysroot is not used for compilation.
 The pinned SDK contains Clang, LLVM binutils, and the Nanvix target sysroot:
 
 ```bash
-SDK=ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
-./z setup --with-docker "$SDK"
+./z setup
 ./z build
 ```
 

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -42,12 +42,6 @@ from nanvix_zutil.paths import (
 
 IS_WINDOWS = sys.platform == "win32"
 
-#: Docker image for cross-compiling Nanvix targets.
-NANVIX_DOCKER_IMAGE = (
-    "ghcr.io/nanvix/nanvix-sdk-c-clang"
-    "@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
-)
-
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_HOME = "NANVIX_HOME"
 _MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
@@ -77,10 +71,6 @@ class SqliteBuild(ZScript):
         "bin/kernel.elf",
         "bin/mkramfs.exe",
     )
-
-    def docker_image(self) -> str:
-        """Return the default Docker image for cross-compilation."""
-        return NANVIX_DOCKER_IMAGE
 
     def _make_args(
         self,


### PR DESCRIPTION
Remove the dead z.py image override and replace explicit setup coordinates with the canonical manifest. Lint and strict typing pass.