### PR TITLE
[ci] E: Update Nanvix SDK

### DIFF
--- a/.nanvix/nanvix.lock
+++ b/.nanvix/nanvix.lock
@@ -2,7 +2,7 @@
 
 [metadata]
 manifest-hash = "sha256:a1ecad4a3c8981f4313836e289fca139bb1889cdf7b3b9ce44c5b83837d504b8"
-nanvix-zutil-version = "0.15.3"
+nanvix-zutil-version = "0.16.1"
 
 [metadata.sdk]
 schema-version = 1


### PR DESCRIPTION
Automated coherent update to verified Nanvix SDK `v0.20.0-sdk.2`. The manifest and lockfile were generated atomically by the target zutils implementation.